### PR TITLE
feat: Save results to matfile

### DIFF
--- a/reise.jl
+++ b/reise.jl
@@ -79,7 +79,7 @@ function save_results(results::Results, filename::String)
                 ),
             )),
         )
-    MAT.matwrite(filename, Dict("mdo_save" => mdo_save))
+    MAT.matwrite(filename, Dict("mdo_save" => mdo_save); compress=true)
 end
 
 


### PR DESCRIPTION
This feature adds the ability to save relevant results from an interval to a matfile. There are 3 main parts:
* a `Results` struct is defined.
* a function `get_results` is defined, which takes a JuMP Model as input and returns a `Results` struct. Within this function, there are two additional new functions which are called:
  * `get_2d_variable_values` takes a Model and a string, and returns the values of all variables whose names contain that string, as a 2d array.
  * `get_2d_constraint_duals` takes a Model and a string, and returns the dual values of all constraints whose names contain that string, as a 2d array. The names of some constraints are not set automatically (e.g. powerbalance) because the JuMP developers haven't decided whether to automatically number block constraints created with the `@constraints` macro (and if so, how to). See https://github.com/JuliaOpt/JuMP.jl/issues/1166
  * These two functions contain similar code to infer whether the order of variables/constraints is "`pg[1,1]`, `pg[1,2]`, ..., `pg[m,n]`" or "`pg[1,1]`, `pg[2,1]`, ..., `pg[m,n]`", to know whether to reshape the returned vector of variables/constraints in row-first or column-first order.
* a function `save_results` is defined, which takes a `Results` struct and a string and saves a properly-nested `.mat` file.

There are also a few miscellaneous updates to docstrings and function return type assertions.