### PR TITLE
feat: save input.mat file with params passed to solver

### DIFF
--- a/reise.jl
+++ b/reise.jl
@@ -205,6 +205,25 @@ end
 
 
 """
+    save_input_mat(case)
+
+Read the original case.mat file, replace relevant parameters from Case struct,
+save a new input.mat file with parameters as they're passed to solver.
+"""
+function save_input_mat(case::Case)
+    case_mat_file = MAT.matopen("case.mat")
+    mpc = read(case_mat_file, "mpc")
+    mpc["gen"][:,10] = case.gen_pmin
+    mpc["gen"][:,19] = case.gen_ramp30
+    mpc["gen_a_new"] = case.gen_a_new
+    mpc["gen_b_new"] = case.gen_b_new
+    mdi = Dict("mpc" => mpc)
+    MAT.matwrite("input.mat", Dict("mdi" => mdi); compress=true)
+    return nothing
+end
+
+
+"""
     make_gen_map(case)
 
 Given a Case object, build a sparse matrix representing generator topology.


### PR DESCRIPTION
This PR addresses https://github.com/intvenlab/REISE.jl/issues/8 by adding a function that saves a matfile with a structure that matches the structure of the matfile that REISE saves. It doesn't reproduce _all_ the fields in the `mdi` struct, but it reproduces `mdi.mpc` with all the fields we care about: modifying Pmin and ramp_30 columns in `mdi.mpc.gen`, and recording linearized cost curves in the new struct fields `mdi.mpc.gen_a_new` and `mdi.mpc.gen_b_new`.

The structure of the saved gencost parameters may need to change once we implement piecewise linearized cost curves (see https://github.com/intvenlab/REISE.jl/issues/5), and in discussions with @rouille about whether/how to save both original cost curves and modified cost curves, but for now this format contains all relevant information.