### PR TITLE
feat: run consecutive intervals

### DIFF
--- a/reise.jl
+++ b/reise.jl
@@ -644,6 +644,7 @@ function run_scenario(;
     end
     GC.gc()
     Gurobi.free_env(env)
+    println("Connection closed successfully!")
 end
 
 


### PR DESCRIPTION
This PR adds a feature to loop over a series of intervals, automatically updating the profiles and adding initial period ramp constraints for every interval after the first one.
Resolves #2.

Example usage:
```
julia> include("./reise.jl")
Main.reise
julia> reise.run_scenario(; interval=24, n_interval=3, start_index=1, outputfolder="output")
Compute Server job ID: a89c4c76-507f-4d2a-b63e-8bdd644bd91f
Capacity available on 'ip-172-31-3-11' - connecting...
Established HTTPS encrypted connection
reading
[...model building output truncated...]
Optimize a model with 1209932 rows, 605592 columns and 2302336 nonzeros
[...model solving output truncated...]
Barrier solved model in 23 iterations and 6.21 seconds
Optimal objective 4.76037212e+07
[...model building output truncated...]
Optimize a model with 1212192 rows, 605592 columns and 2304596 nonzeros
[...model solving output truncated...]
Barrier solved model in 31 iterations and 13.10 seconds
Optimal objective 4.80550312e+07
[...model building output truncated...]
Optimize a model with 1212192 rows, 605592 columns and 2304596 nonzeros
[...model solving output truncated...]
Barrier solved model in 29 iterations and 12.87 seconds
Optimal objective 4.75733841e+07


Compute Server communication statistics:
  Sent: 36.6 MBytes in 2332 msgs and 0.00s (0.00 MB/s)
  Received: 23.1 MBytes in 4130 msgs and 3.16s (7.30 MB/s)

Ptr{Nothing} @0x0000000000000000
```

The final `Ptr{Nothing}` line is the output from freeing the Gurobi `env`, which ends the cloud server job (or, in the case of a local solver, stops the solver process) once all relevant results have been extracted from the Gurobi model.

In `output/` (which did not previously exist, and was therefore automatically created), we now have `result_0.mat`, `result_1.mat`, and `result_2.mat`.