### PR TITLE
Fix dcline load bug

### DIFF
--- a/src/read.jl
+++ b/src/read.jl
@@ -20,7 +20,11 @@ function read_case(filepath)
 
     # DC branches
     if "dcline" in keys(mpc)
-        case["dclineid"] = dropdims(mpc["dclineid"], dims=2)
+        if isa(mpc["dclineid"], Int)
+            case["dclineid"] = Int64[mpc["dclineid"]]
+        else
+            case["dclineid"] = dropdims(mpc["dclineid"], dims=2)
+        end
         case["dcline_from"] = convert(Array{Int,1}, mpc["dcline"][:,1])
         case["dcline_to"] = convert(Array{Int,1}, mpc["dcline"][:,2])
         case["dcline_rating"] = mpc["dcline"][:,11]


### PR DESCRIPTION
### Purpose

Fix the importing of DC line data

### What is the code doing

Instead of searching for a variable named `"dcline"` in the matfile, it looks for an entry within `mpc` named `"dcline"`. When there is only one DC line, this field is an int, otherwise it is an array, so the code also converts an int to an array when necessary.

### Time estimate

Half an hour. You can try it locally using the files from `tmp/scenario_97`, examining the `result_*.mat` files in MATLAB.

```
julia> include("src/REISE.jl")
Main.REISE

julia> REISE.run_scenario(;
    interval=24, n_interval=X, start_index=1, outputfolder="[wherever]/scenario_97/julia_output",
    inputfolder="[wherever]/scenario_97")
```