### PR TITLE
feat/fix: fix matfile cell array load, convert input.mat to v7

### DIFF
--- a/pyreisejl/utility/extract_data.py
+++ b/pyreisejl/utility/extract_data.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 import time
 import os
+from scipy.io import savemat
 import shutil
 
 from tqdm import tqdm
@@ -205,7 +206,7 @@ def calculate_averaged_congestion(congl, congu):
 
 
 def copy_input(scenario_id):
-    """Copies input file.
+    """Copies input file, converting matfile from v7.3 to v7 on the way.
 
     :param str scenario_id: scenario id
     """
@@ -215,7 +216,12 @@ def copy_input(scenario_id):
                        'input.mat')
     dst = os.path.join(const.INPUT_DIR,
                        '%s_grid.mat' % scenario_id)
-    shutil.copyfile(src, dst)
+    input_mpc = helpers.load_mat73(src)
+    # Change the datatype of genfuel to yield a cell array in the matfile
+    new_genfuel = np.array(input_mpc['mdi']['mpc']['genfuel'], dtype=np.object)
+    new_genfuel = np.expand_dims(new_genfuel, axis=1)
+    input_mpc['mdi']['mpc']['genfuel'] = new_genfuel
+    savemat(dst, input_mpc, do_compression=True)
 
 
 def delete_output(scenario_id):

--- a/pyreisejl/utility/helpers.py
+++ b/pyreisejl/utility/helpers.py
@@ -19,15 +19,6 @@ def sec2hms(seconds):
     return hours, minutes, seconds
 
 
-def string_from_int_matrix(array):
-    """Convert matrices of integers to strings.
-
-    :param numpy.ndarray array: array of ints, each representing a character
-    :return: (*str*) -- string of converter characters.
-    """
-    return ''.join([str(c[0]) for c in np.char.mod('%c', array)])
-
-
 def load_mat73(filename):
     """Load a HDF5 matfile, and convert to a nested dict of numpy arrays.
 
@@ -56,7 +47,9 @@ def load_mat73(filename):
                 data = data.swapaxes(-1, -2)
             if data[0].dtype == np.uint16:
                 # Convert matrices of integers to strings
-                data = np.array([string_from_int_matrix(arr) for arr in data])
+                data = np.array(
+                    [''.join([str(c[0]) for c in np.char.mod('%c', array)])
+                    for array in data])
             output[k] = data
         return output
 

--- a/pyreisejl/utility/tests/test_helpers.py
+++ b/pyreisejl/utility/tests/test_helpers.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from pyreisejl.utility.helpers import sec2hms


### PR DESCRIPTION
### Purpose

Fix the function to parse HDF5 matfiles so that it can handle array of strings; `_parse_hdf5_matfile()` is renamed to `load_mat73()` and moved to the `helpers.py` file.

When copying the `input.mat` file, instead of straight copying, parse the HDF5 matfile and then save as a v7 matfile so that it can be read by the MATReader object.

### What is the code doing

`copy_input()` has been changed from a simple copy to a load-convert-and-save process.

`load_mat73()` is a refactoring of `_parse_hdf5_matfile()`, but completely re-written to be compatible with arrays of strings, which (at least coming from our implementation in REISE.jl) are stored as HDF5 reference objects to Nx1 dimensional arrays of uint16 datatype, where each value is an integer corresponding to a character. So we need to interpret `array([[104], [121], [100], [114], [111]])` as `'hydro'`. See `string_from_int_matrix()`.

In the process or rewriting this function, a lot of magicky-looking code has been eliminated.

### Time to review

The code can probably be reviewed in about an hour. To test, you can run REISE.jl locally on the input files for a scenario on the server, and REISE.jl will create an `input.mat` file in the results folder. This file can be converted using the code in `copy_input()`, and can be loaded back into MATLAB and you can run `isequal()` on the two structs (before and after) to confirm that they are equal.