### PR TITLE
feat: set Pmin of status 0 generators to 0

### DIFF
--- a/src/prepare.jl
+++ b/src/prepare.jl
@@ -12,6 +12,8 @@ function reise_data_mods(case::Dict; num_segments::Int=1)::Case
     case["gen_pmin"][nuclear_idx] = 0.95 * (case["gen_pmax"][nuclear_idx])
     geo_idx = case["genfuel"] .== "geothermal"
     case["gen_pmin"][geo_idx] = 0.95 * (case["gen_pmax"][geo_idx])
+    offstatus_idx = case["gen_status"] .== 0
+    case["gen_pmin"][offstatus_idx] .= 0
 
     # Save original gencost to gencost_orig
     case["gencost_orig"] = copy(case["gencost"])

--- a/src/read.jl
+++ b/src/read.jl
@@ -45,6 +45,7 @@ function read_case(filepath)
     genfuel = dropdims(mpc["genfuel"], dims=2)
     case["genfuel"] = convert(Array{String,1}, genfuel)
     case["gen_bus"] = convert(Array{Int,1}, mpc["gen"][:,1])
+    case["gen_status"] = mpc["gen"][:,8]
     case["gen_pmax"] = mpc["gen"][:,9]
     case["gen_pmin"] = mpc["gen"][:,10]
     case["gen_ramp30"] = mpc["gen"][:,19]

--- a/src/types.jl
+++ b/src/types.jl
@@ -20,6 +20,7 @@ Base.@kwdef struct Case
     genid::Array{Int64,1}
     genfuel::Array{String,1}
     gen_bus::Array{Int64,1}
+    gen_status::BitArray{1}
     gen_pmax::Array{Float64,1}
     gen_pmin::Array{Float64,1}
     gen_ramp30::Array{Float64,1}


### PR DESCRIPTION
### Purpose

Set the Pmin for generators with status `0` (off) to zero, to match what is currently done in REISE. See https://github.com/intvenlab/REISE/blob/develop/generic/scenario_matlab_script.m#L88. All other generators besides coal, nuclear, and geothermal already have their Pmins set to zero, and of these types, in our dataset nuclear and geothermal never have statuses of `0`, so this change will only affect coal generators.

@BainanXia and I discovered this problem while working on https://github.com/intvenlab/REISE.jl/pull/33.

### What is the code doing

In `types.jl`, adding a new field within the `Case` object to hold generator status bits.

In `read.jl`, populating this new field with data from the `case.mat` file.

In `prepare.jl`, using this new field to set Pmin to 0 for generators with status `0`.

### Documentation of effectiveness

The new code was run on the data from scenario 87, with the resulting `input.mat` file compared to what is generated using what's currently in `develop`. In MATLAB:
```
>> input_reference = load('julia_output_wo_pmin/input.mat');
>> input_reference = input_reference.mdi.mpc;
>> input_test = load('julia_output_pmin/input.mat');
>> input_test = input_test.mdi.mpc;
>> test_fields = fieldnames(input_test);
>> for i = 1:size(test_fields,1)
        f = test_fields{i}
        isequal(input_test.(f), input_reference.(f))
   end

f =
    'genid'
ans =
  logical
   1
f =
    'baseMVA'
ans =
  logical
   1
f =
    'gen'
ans =
  logical
   0
f =
    'genfuel'
ans =
  logical
   1
f =
    'branch'
ans =
  logical
   1
f =
    'branchid'
ans =
  logical
   1
f =
    'gencost_orig'
ans =
  logical
   1
f =
    'bus'
ans =
  logical
   1
f =
    'version'
ans =
  logical
   1
f =
    'gencost'
ans =
  logical
   0
```
The only differences are in `gen` and `gencost`.
```
>> gencost_diff = input_test.gencost - input_reference.gencost;
>> sum(gencost_diff)
ans =
   1.0e+04 *
         0         0         0         0   -0.1067   -2.6550   -0.0000   -0.0000
>> find(sum(gencost_diff, 2))

ans =
         108
         688
         718
         719
        1000
        1329
        1330
        1701
        1724
        1727
        1798
        1908
        1947
        1956
        1970
        1971
        1972
        1973
        2190
        2192
        2193
        2220
        2225
        2226
        2227
        2267
        2401
```
Differences are only in the (x0,y0) point columns, and only for these 27 generators.
```
>> input_test.gencost(108, :)

ans =
   1.0e+04 *
    0.0001         0         0    0.0002         0    0.1404    0.0730    2.1233

>> input_reference.gencost(108, :)

ans =
   1.0e+04 *
    0.0001         0         0    0.0002    0.0357    1.0843    0.0730    2.1233
```
Looking at the first one for an example, we can confirm now that x0 = 0. y0 can still be nonzero due to c0 values. All other columns remain the same.
```
>> orig_case = load('case.mat');
>> coal_idx = strcmp(orig_case.mpc.genfuel,'coal');
>> offstatus_idx = orig_case.mpc.gen(:,8) == 0;
>> find(coal_idx & offstatus_idx) == find(sum(gencost_diff, 2))

ans =

  27×1 logical array
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
```
The only rows that are different are the rows of coal generators whose statuses were originally `0`.
```
>> gen_diff = input_test.gen - input_reference.gen;
>> sum(gen_diff)

ans =
   1.0e+03 *
  Columns 1 through 8
         0         0         0         0         0         0         0         0
  Columns 9 through 16
         0   -1.0668         0         0         0         0         0         0
  Columns 17 through 24
         0         0       NaN         0         0         0         0         0
  Column 25
         0
```
The only differences are in column 10, Pmin. Column 19 is RAMP_30, which we are defining as `Inf`, so we're getting `Inf - Inf = Nan` values
```
>> gen_diff(:, 19) = 0;
>> find(coal_idx & offstatus_idx) == find(sum(gen_diff, 2))

ans =

  27×1 logical array

   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
   1
```
Once we remove the `NaN` values, the only differences are in the coal rows with original statuses of `0`.

### Time to review

An hour or less. The code changes are minimal, but you may want to test the effect of the changes for yourself.