### PR TITLE
feat: save supplementary grid data in input.mat

### DIFF
--- a/pyreisejl/utility/extract_data.py
+++ b/pyreisejl/utility/extract_data.py
@@ -217,10 +217,6 @@ def copy_input(scenario_id):
     dst = os.path.join(const.INPUT_DIR,
                        '%s_grid.mat' % scenario_id)
     input_mpc = helpers.load_mat73(src)
-    # Change the datatype of genfuel to yield a cell array in the matfile
-    new_genfuel = np.array(input_mpc['mdi']['mpc']['genfuel'], dtype=np.object)
-    new_genfuel = np.expand_dims(new_genfuel, axis=1)
-    input_mpc['mdi']['mpc']['genfuel'] = new_genfuel
     savemat(dst, input_mpc, do_compression=True)
 
 


### PR DESCRIPTION
### Purpose

Save the supplementary data needed to recreate a complete Grid object solely from an `input.mat` file. This will be needed so that we can construct a Grid from a Scenario which has been run using REISE.jl.

### What is the code doing

In `src/types.jl`: adding new fields to the struct to hold the new data.

In `src/read.jl`: reading these data from an input `case.mat` file.

In `src/save.jl`: saving these data in our `case.mat` file.

In `pyreisejl/utility/helpers.py`: refactoring the HDF5 extraction/conversion algorithm to be able to handle arrays of mixed type: strings (represented as arrays of `np.uint16`) & floats. The list comprehension for the `np.char.mod` call is extended with a type check on each element, so that it does not try to convert floats. Arrays of *all* strings are coerced into being saved as 1D cell arrays, not 2D char arrays, using the reassignment to `np.object` type. Finally, arrays which had been flattened (so that we could perform list comprehensions on them) are restored to their original shapes as necessary.

In `pyreisejl/utility/extract_data.py`: removing type coercion from `copy_input()` that is now contained in `load_mat73()`

### Time to review

An hour or less. The REISE.jl code is extremely simple. Similar to https://github.com/intvenlab/REISE.jl/pull/33, the new code in `load_mat73()` can be tested by reproducing `copy_input()` locally and testing that calling `isequal` on the input matfile struct and the output matfile struct returns True.