### PR TITLE
feat: fetch 'wind_offshore' profiles from wind.csv

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -140,7 +140,8 @@ function _build_model(; case::Case, storage::Storage,
                              num_storage)::SparseMatrixCSC
     end
     # Subsets
-    gen_wind_idx = gen_idx[findall(case.genfuel .== "wind")]
+    gen_wind_idx = gen_idx[findall(
+        (case.genfuel .== "wind") .| (case.genfuel .== "wind_offshore"))]
     gen_solar_idx = gen_idx[findall(case.genfuel .== "solar")]
     gen_hydro_idx = gen_idx[findall(case.genfuel .== "hydro")]
     renewable_idx = sort(vcat(gen_wind_idx, gen_solar_idx, gen_hydro_idx))


### PR DESCRIPTION
### Purpose

Fetch 'wind_offshore' profiles from wind.csv. Analogous to https://github.com/intvenlab/REISE/pull/64.

### What is the code doing

When finding the indices of generators of type `'wind'`, also grab the indices of generators of type `'wind_offshore'`.

### Time to review

It is one line. Five minutes if you want to play around in Julia to verify that the call works as expected on dummy data.
```
julia> a = [false, true, false];

julia> b = [false, false, true];

julia> findall(a)
1-element Array{Int64,1}:
 2

julia> findall(b)
1-element Array{Int64,1}:
 3

julia> findall(a .| b)
2-element Array{Int64,1}:
 2
 3
```