### PR TITLE
fix: modify call.py for proper value, type, syntax

### DIFF
--- a/pyreisejl/utility/call.py
+++ b/pyreisejl/utility/call.py
@@ -102,18 +102,25 @@ def scenario_julia_call(scenario_info, start_index, end_index):
     :param int end_index: end index.
     """
 
+    from julia.api import Julia
+    jl = Julia(compiled_modules=False)
     from julia import Main
     from julia import REISE
 
     interval = int(scenario_info['interval'].split('H', 1)[0])
-    n_interval = (end_index - start_index) / interval
+    n_interval = int((end_index - start_index + 1) / interval)
 
     input_dir = os.path.join(const.EXECUTE_DIR,
                              'scenario_%s' % scenario_info['id'])
     output_dir = os.path.join(const.EXECUTE_DIR,
                               'scenario_%s/output/' % scenario_info['id'])
 
-    REISE.run_scenario(interval, n_interval, start_index, input_dir, output_dir)
+    REISE.run_scenario(
+        interval=interval,
+        n_interval=n_interval,
+        start_index=start_index,
+        inputfolder=input_dir,
+        outputfolder=output_dir)
     Main.eval('exit()')
 
 


### PR DESCRIPTION
### Purpose

Fix bugs in call.py. https://github.com/intvenlab/REISE.jl/pull/32 was merged in without adequate testing, and it seems there are some problems that need fixing.

### What is the code doing

Lines 105 & 106: Modifying the python/julia communication, to fix python executable static linkings to libpython. See https://pyjulia.readthedocs.io/en/latest/troubleshooting.html#turn-off-compilation-cache. Note: there may be more efficient ways to solve this problem, I arbitrarily picked the one that the troubleshooting page said was easiest.

Lines 109/111: modifying the calculation of n_interval so that it returns the right value as an integer, rather than a fractional float caused by an off-by-one index calculation.

Lines 116/118-123: modifying the call to `REISE.run_scenario`. The semicolon in the function definition for `run_scenario` is like the `*` in the argument list of a python function definition: all parameters afterwards need to be keyword arguments, or the call will fail.

### Testing

This modified `call.py` was tested successfully in scenarios 483 & 484, run via the Scenario object on my laptop, and each scenario produced the right number of output `result_*.mat` files.

### Time to Review

The actual code changes: 5 minutes. Up to half an hour if you want to dig more into the details of the python/julia compatibility issue and other potential solutions.