### PR TITLE
fix: assorted bugfixes in extract_data.py

### DIFF
--- a/pyreisejl/utility/extract_data.py
+++ b/pyreisejl/utility/extract_data.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import time
 import os
-from scipy.io import savemat
+from scipy.io import loadmat, savemat
 import shutil
 
 from tqdm import tqdm


### PR DESCRIPTION
### Purpose

Make `extract_data.py` work.

### What is the code doing

Line 9: import `loadmat`, since we need it to load `case_storage.mat` (or try to anyway).

Line 99: specify the extension of the `result_*` filename (I think `scipy.io.loadmat` is smart enough to do it automatically, but since we aren't using that anymore, we need to specify more carefully).

Line 137: access the scenario id from `scenario_info`.

Line 219: correct the reference to `load_mat73`.

### Testing

Tested to extract scenarios 483, 487, and 488 on the server.

### Time to review

Five to fifteen minutes.