### PR TITLE
fix: go back to JuMP v0.20 (undoes #47)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,4 +15,4 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-JuMP = "0.20, 0.21"
+JuMP = "0.20"

--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ pkg> activate .
 
 Another way is to install the package using the list of dependencies specified
 in the `Project.toml` file, which will pull the most recent allowed version of
-the dependencies. Importantly, there may be packages for which the latest
-version does not maintain backward-compatibility, so this method is less stable
-than `instantiate`.
+the dependencies. Currently, this package is known to be compatible with JuMP
+v0.20, but not v0.21; this is specified in the `Project.toml` file, but there
+may be other packages for which the latest version does not maintain
+backward-compatibility.
 
 This package is not registered. Therefore, it must be added to a Julia
 environment either directly from github:


### PR DESCRIPTION
### Purpose

Based on testing, there is more to JuMP v0.21 compatibility than just `with_optimizer`, so we should go back to requiring v0.20.

### What is the code doing

Specifying JuMP v0.20 only, not v0.20 or v0.21.

### Time to review

Five minutes.