### PR TITLE
feat: allow default value for outputfolder

### DIFF
--- a/src/REISE.jl
+++ b/src/REISE.jl
@@ -36,8 +36,10 @@ Run a scenario consisting of several intervals.
 """
 function run_scenario(;
         num_segments::Int=1, interval::Int, n_interval::Int, start_index::Int,
-        inputfolder::String, outputfolder::String)
+        inputfolder::String, outputfolder::Union{String, Nothing}=nothing)
     # Setup things that build once
+    # If outputfolder not given, by default assign it inside inputfolder
+    isnothing(outputfolder) && (outputfolder = joinpath(inputfolder, "output"))
     # If outputfolder doesn't exist (isdir evaluates false) create it (mkdir)
     isdir(outputfolder) || mkdir(outputfolder)
     stdout_filepath = joinpath(outputfolder, "stdout.log")


### PR DESCRIPTION
### Purpose

Allow `run_scenario` to be called in a less verbose fashion by having a default relative path for `outputfolder` (relative to `inputfolder`).

`run_scenario(; interval=24, n_interval=366, start_index=1, inputfolder="/foo/bar/", outputfolder="/foo/bar/output")` simplifies to `run_scenario(; interval=24, n_interval=366, start_index=1, inputfolder="/foo/bar/")`, unless we want to specify an alternate output location.

### What is the code doing

- Modifying the type of the `outputfolder` argument to be either `nothing` or a `String` (`nothing` is like `None` in python, and is a `Nothing` object like the `NoneType` class in python), and adding a default value of `nothing`.
- Adding a short-circuit evaluation that checks if `outputfolder` is `nothing`, and if so then assigns it to an `output` subdirectory of `inputfolder`. Similar to `isdir(outputfolder) || mkdir(outputfolder)` below, the `&&` ensures that the second expression is only run if the first expression evaluates `true` (for `||`, the second expression is only evaluated if the first one evaluated to `false`).

### Time to review

15 minutes.