### PR TITLE
feat: allow specification of number of threads to run with

### DIFF
--- a/src/REISE.jl
+++ b/src/REISE.jl
@@ -36,7 +36,8 @@ Run a scenario consisting of several intervals.
 """
 function run_scenario(;
         num_segments::Int=1, interval::Int, n_interval::Int, start_index::Int,
-        inputfolder::String, outputfolder::Union{String, Nothing}=nothing)
+        inputfolder::String, outputfolder::Union{String, Nothing}=nothing,
+        threads::Union{Int, Nothing}=nothing)
     # Setup things that build once
     # If outputfolder not given, by default assign it inside inputfolder
     isnothing(outputfolder) && (outputfolder = joinpath(inputfolder, "output"))
@@ -56,6 +57,8 @@ function run_scenario(;
         "interval_length" => interval,
         )
     solver_kwargs = Dict("Method" => 2, "Crossover" => 0)
+    # If a number of threads is specified, add to solver settings dict
+    isnothing(threads) || (solver_kwargs["Threads"] = threads)
     println("All preparation complete!")
     # While redirecting stdout and stderr...
     println("Redirecting outputs, see stdout.log & stderr.err in outputfolder")


### PR DESCRIPTION
### Purpose

Allow the user to control how many threads are used by Gurobi.

### What is the code doing

- We add to `run_scenario()` a new optional parameter `threads`, which takes an `Int` or `nothing`.
- If `threads` is not `nothing` (i.e. an `Int` has been passed), we assign a new key/value pair in the solver keywords dict, which gets passed to Gurobi when the model is instantiated for the first time (see https://github.com/Breakthrough-Energy/REISE.jl/blob/develop/src/loop.jl#L50).

### Validation

#### Texas

Running Gurobi locally using files from scenario 526 (Texas), with `threads=4` we see typical CPU utilization of 250-260% (via `top`), and one year took 17 minutes to run (24-hour resolution). When `threads` is not specified (defaults to number of physical cores, 64), we see CPU utilization of 800-1300%, and one year took 16 minutes to run (24-hour resolution). More cores does not always equal more faster! For 24-hour Texas, most of the time for each iteration is not actually within the Barrier method, but in the problem setup & writing.

#### Western

Using files from scenario 667 (Western), with `threads=4` we see typical CPU utilization of 300-360% (interleaved with 100%, which I'm guessing is saving results or pre-solving) and one month took 5 minutes to run. When threads is not specified, we see CPU utilization of 900-2000% (interleaved with 100%) and one month took 5 minutes to run. Again, not faster!

#### Eastern

Using files from scenario 511 (Eastern), with `threads=16` we see typical CPU utilization of around 1900% (maybe there is some computational overhead for Julia managing the Gurobi process?), interleaved with 400% CPU utilization (when pre-solving) and one week took 11 minutes to run (discarding runtimes for the first two intervals because they require build/compilation time). When threads is not specified, we see CPU utilization of around 3200% and one week took 10 minutes to run.

#### Conclusions

We may not yet have a great understanding of when we should use more cores vs. when we should use fewer, but we at least know how to control the number of cores used.

### Time to review

15 minutes.