### PR TITLE
feat: select number of gurobi threads from python

### DIFF
--- a/pyreisejl/utility/call.py
+++ b/pyreisejl/utility/call.py
@@ -1,5 +1,5 @@
 from pyreisejl.utility import const
-from pyreisejl.utility.helpers import sec2hms
+from pyreisejl.utility.helpers import sec2hms, WrongNumberOfArguments
 
 import numpy as np
 import os
@@ -45,6 +45,7 @@ def launch_scenario(scenario_id, threads=None):
     """Launches the scenario.
 
     :param str scenario_id: scenario index.
+    :param None/int threads: number of threads to use, None defaults to auto.
     """
 
     scenario_info = get_scenario(scenario_id)
@@ -93,6 +94,7 @@ def launch_scenario(scenario_id, threads=None):
         start_index=start_index,
         inputfolder=input_dir,
         outputfolder=output_dir,
+        threads=threads,
     )
     Main.eval("exit()")
 
@@ -112,12 +114,12 @@ def launch_scenario(scenario_id, threads=None):
 if __name__ == "__main__":
     import sys
 
-    if len(sys.argv == 2):
+    if len(sys.argv) == 2:
         # First argument is the name of the script
         # Second argument is the scenario number to run
         launch_scenario(sys.argv[1])
-    elif len(sys.argv == 3):
+    elif len(sys.argv) == 3:
         # Third argument is the number of threads to use
         launch_scenario(sys.argv[1], int(sys.argv[2]))
     else:
-        raise ArgumentError(f"Got bad number of arguments: {len(sys.argv) - 1}")
+        raise WrongNumberOfArguments(f"Must specify either one or two arguments")

--- a/pyreisejl/utility/helpers.py
+++ b/pyreisejl/utility/helpers.py
@@ -2,6 +2,12 @@ import h5py
 import numpy as np
 
 
+class WrongNumberOfArguments(TypeError):
+    """To be used when the wrong number of arguments are specified at command line."""
+
+    pass
+
+
 def sec2hms(seconds):
     """Converts seconds to hours, minutes, seconds
 


### PR DESCRIPTION
### Purpose

Following up on https://github.com/Breakthrough-Energy/REISE.jl/pull/66 which allowed us to specify the number of threads to use in the Julia function, we would like to be able to pass this choice via python, so that it can ultimately be triggered via the Execute object.

### What is the code doing

- Removing the unused parallel call functionality.
- Adding an optional second command line argument specifying the number of threads to be used, which gets passed to `launch_scenario_performance`, `scenario_julia_call`, and finally `run_scenario` (within REISE.jl).

### Validation

Can't fully test until the Scenario framework is set up, but we know that thread selection within Julia works as intended, and these changes are pretty transparent.

### Time to review

15 minutes. I only halfway removed the parallelization, we may want to either fully remove it and combine `launch_scenario_performance` and `scenario_julia_call` if we do not anticipate using this functionality in the future.

