### PR TITLE
fix: remove Julia exit which kills python

### DIFF
--- a/pyreisejl/utility/call.py
+++ b/pyreisejl/utility/call.py
@@ -6,7 +6,6 @@ import os
 import pandas as pd
 
 from collections import OrderedDict
-from multiprocessing import Process
 from time import time
 
 
@@ -71,8 +70,6 @@ def launch_scenario(scenario_id, threads=None):
     # Update status in ExecuteList.csv on server
     insert_in_file(const.EXECUTE_LIST, scenario_info["id"], "2", "running")
 
-    start = time()
-
     # Import these within function because there is a lengthy compilation step
     from julia.api import Julia
 
@@ -88,6 +85,7 @@ def launch_scenario(scenario_id, threads=None):
         const.EXECUTE_DIR, "scenario_%s/output/" % scenario_info["id"]
     )
 
+    start = time()
     REISE.run_scenario(
         interval=interval,
         n_interval=n_interval,
@@ -96,8 +94,6 @@ def launch_scenario(scenario_id, threads=None):
         outputfolder=output_dir,
         threads=threads,
     )
-    Main.eval("exit()")
-
     end = time()
 
     # Update status in ExecuteList.csv on server


### PR DESCRIPTION
### Purpose

Clean up after https://github.com/Breakthrough-Energy/REISE.jl/pull/67 which did not fully remove the mostly unused parallelization.

### What is the code doing

Previously, the `multiprocess.Process` invocation of `scenario_julia_call` did not mind when we called `Main.eval("exit()")`, telling Julia to exit which had the effect of killing the python process. Since this was the end of the child process anyway, the parent process (`launch_scenario_performance`) continued just fine. We only had one child process so we weren't really parallel, but killing the child did not kill the parent. We combined the child and the parent and now the `Main.eval("exit()")` becomes a problem.

We now remove the `Main.eval("exit()")` line which was never really needed anyway (there's no hanging Julia process after the python script completes).

We also condense the `time()` calls a bit to save on whitespace.

### Time to review

It is one functional line change.