### PR TITLE
fix: refactor load_shed var for JuMP v0.21

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -226,7 +226,7 @@ function _build_model(m::JuMP.Model; case::Case, storage::Storage,
     end)
     if load_shed_enabled
         JuMP.@variable(m,
-            0 <= load_shed[i in 1:sets.num_load_bus, j in hour_idx]
+            0 <= load_shed[i in 1:sets.num_load_bus, j in 1:interval_length]
             <= bus_demand[sets.load_bus_idx[i], j],
             container=Array)
     end


### PR DESCRIPTION
### Purpose

Another follow-up to https://github.com/Breakthrough-Energy/REISE.jl/pull/62, where apparently JuMP v0.21 needs more hints.

The problem can be reproduced using `develop` by running
```julia
import REISE
REISE.run_scenario(; interval=24, n_interval=7, start_index=(151*24+1), inputfolder="/mnt/bes/pcm/tmp/scenario_1113", outputfolder="/mnt/bes/pcm/tmp/scenario_1113/output_whatever")
```

It gets through three intervals, and then runs into numerical issues, and when load shedding is enabled we see:
```
ERROR: Index set for array is not one-based interval.
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] _oneto(::Base.OneTo{Int64}) at /home/dolsen/.julia/packages/JuMP/YXK4e/src/Containers/container.jl:76
 [3] _broadcast_getindex_evalf at ./broadcast.jl:631 [inlined]
 [4] _broadcast_getindex at ./broadcast.jl:604 [inlined]
 [5] (::Base.Broadcast.var"#19#20"{Base.Broadcast.Broadcasted{Base.Broadcast.Style{Tuple},Nothing,typeof(JuMP.Containers._oneto),Tuple{Tuple{Base.OneTo{Int64},UnitRange{Int64}}}}})(::Int64) at ./broadcast.jl:1024
 [6] ntuple at ./ntuple.jl:42 [inlined]
 [7] copy at ./broadcast.jl:1024 [inlined]
 [8] materialize at ./broadcast.jl:820 [inlined]
 [9] container(::Function, ::JuMP.Containers.VectorizedProductIterator{Tuple{Base.OneTo{Int64},UnitRange{Int64}}}, ::Type{Array}) at /home/dolsen/.julia/packages/JuMP/YXK4e/src/Containers/container.jl:80
 [10] macro expansion at /home/dolsen/.julia/packages/JuMP/YXK4e/src/macros.jl:79 [inlined]
 [11] _build_model(::JuMP.Model; case::REISE.Case, storage::REISE.Storage, start_index::Int64, interval_length::Int64, demand_scaling::Float64, load_shed_enabled::Bool, load_shed_penalty::Int64, trans_viol_enabled::Bool, trans_viol_penalty::Int64, initial_ramp_enabled::Bool, initial_ramp_g0::Array{Float64,1}, storage_e0::Array{Float64,1}) at /home/bes/pcm/REISE.jl/src/model.jl:228
 [12] interval_loop(::Gurobi.Env, ::Dict{String,Any}, ::Dict{String,Int64}, ::Int64, ::Int64, ::Int64, ::String, ::String) at /home/bes/pcm/REISE.jl/src/loop.jl:148
 [13] (::REISE.var"#101#102"{Int64,Int64,Int64,String,Gurobi.Env,Dict{String,Any},Dict{String,Int64}})() at /home/bes/pcm/REISE.jl/src/REISE.jl:67
 [14] #95 at /home/bes/pcm/REISE.jl/src/save.jl:113 [inlined]
 [15] redirect_stderr(::REISE.var"#95#99"{REISE.var"#101#102"{Int64,Int64,Int64,String,Gurobi.Env,Dict{String,Any},Dict{String,Int64}}}, ::IOStream) at ./stream.jl:1152
 [16] #94 at /home/bes/pcm/REISE.jl/src/save.jl:112 [inlined]
 [17] redirect_stdout(::REISE.var"#94#98"{IOStream,REISE.var"#101#102"{Int64,Int64,Int64,String,Gurobi.Env,Dict{String,Any},Dict{String,Int64}}}, ::IOStream) at ./stream.jl:1152
 [18] #93 at /home/bes/pcm/REISE.jl/src/save.jl:111 [inlined]
 [19] open(::REISE.var"#93#97"{IOStream,REISE.var"#101#102"{Int64,Int64,Int64,String,Gurobi.Env,Dict{String,Any},Dict{String,Int64}}}, ::String, ::Vararg{String,N} where N; kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at ./io.jl:298
 [20] open at ./io.jl:296 [inlined]
 [21] #92 at /home/bes/pcm/REISE.jl/src/save.jl:110 [inlined]
 [22] open(::REISE.var"#92#96"{REISE.var"#101#102"{Int64,Int64,Int64,String,Gurobi.Env,Dict{String,Any},Dict{String,Int64}},String}, ::String, ::Vararg{String,N} where N; kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at ./io.jl:298
 [23] open(::Function, ::String, ::String) at ./io.jl:296
 [24] redirect_stdout_stderr at /home/bes/pcm/REISE.jl/src/save.jl:109 [inlined]
 [25] run_scenario(; num_segments::Int64, interval::Int64, n_interval::Int64, start_index::Int64, inputfolder::String, outputfolder::String, threads::Nothing) at /home/bes/pcm/REISE.jl/src/REISE.jl:65
 [26] top-level scope at REPL[2]:1
```

### What is the code doing

No changes to operation, we are just more explicit that `hour_idx` still equals `1:interval_length` as originally declared in 181.

### Validation

Tested successfully on the same code:
```julia
import REISE
REISE.run_scenario(; interval=24, n_interval=7, start_index=(151*24+1), inputfolder="/mnt/bes/pcm/tmp/scenario_1113", outputfolder="/mnt/bes/pcm/tmp/scenario_1113/output_whatever")
```

The run finishes successfully and the `result_*.mat` files are larger since they contain the `load_shed` results.

### Time to review

It is one line. You will have spent much more time reading this PR than reviewing the code itself.