### PR TITLE
feat, refactor: added new entry point to run call.py without PowerSimData

### DIFF
--- a/pyreisejl/utility/tests/test_helpers.py
+++ b/pyreisejl/utility/tests/test_helpers.py
@@ -1,7 +1,15 @@
 import numpy as np
 import pytest
+import pandas as pd
+from io import StringIO
 
-from pyreisejl.utility.helpers import sec2hms
+from pyreisejl.utility.helpers import (
+    sec2hms,
+    extract_date_limits,
+    validate_time_format,
+    validate_time_range,
+    InvalidDateArgument,
+)
 
 
 def test_sec2hms_arg_type():
@@ -34,3 +42,62 @@ def test_sec2hms_hours_only():
 def test_sec2hms_hms():
     seconds = 72 * 3600 + 45 * 60 + 15
     assert sec2hms(seconds) == (72, 45, 15)
+
+
+def test_validate_time_format_type():
+    date = "2016/01/01"
+    with pytest.raises(InvalidDateArgument):
+        validate_time_format(date)
+
+
+def test_validate_time_format_day():
+    date = "2016-01-01"
+    assert validate_time_format(date) == pd.Timestamp("2016-01-01 00:00:00")
+
+
+def test_validate_time_format_hours():
+    date = "2016-01-01 12"
+    assert validate_time_format(date) == pd.Timestamp("2016-01-01 12:00:00")
+
+
+def test_validate_time_format_min():
+    date = "2016-01-01 12:30"
+    assert validate_time_format(date) == pd.Timestamp("2016-01-01 12:30:00")
+
+
+def test_validate_time_format_sec():
+    date = "2016-01-01 12:30:30"
+    assert validate_time_format(date) == pd.Timestamp("2016-01-01 12:30:30")
+
+
+def test_validate_time_format_end_date():
+    date = "2016-01-01"
+    assert validate_time_format(date, end_date=True) == pd.Timestamp(
+        "2016-01-01 23:00:00"
+    )
+
+
+def test_validate_time_range():
+    date = "2020-06-01"
+    min_ts = "2016-01-01"
+    max_ts = "2016-12-31"
+    with pytest.raises(InvalidDateArgument):
+        validate_time_range(date, min_ts, max_ts)
+
+
+def test_extract_date_limits():
+    example_csv = StringIO()
+    example_csv.write(
+        """UTC, 301, 302, 303, 304, 305, 306, 307, 308
+1/1/16 0:00, 2965.292134, 1184.906904, 1676.760454, 4556.579997, 18295.21119, 8611.226983, 14600.71, 1830.2
+1/1/16 1:00, 3010.513011, 1215.345962, 1731.231093, 4684.33594, 18781.27034, 8959.356, 14655.5098, 1977.303
+1/1/16 2:00, 3002.107911, 1192.115238, 1709.06971, 4536.162029, 18296.94916, 8744.25244, 14236.594, 1849.04
+"""
+    )
+    example_csv.seek(0)
+
+    assert extract_date_limits(example_csv) == (
+        pd.Timestamp("2016-01-01 00:00:00"),
+        pd.Timestamp("2016-01-01 02:00:00"),
+        "H",
+    )


### PR DESCRIPTION
### Purpose

Remove dependency of call.py on PowerSimData, adding another entry point to call.py that is not a scenario ID.

### What is the code doing?
This code now runs independently of PowerSim data by passing in flags to define the required and options parameters to run a simulation. The flags are documented below, which is the result of running `python call.py -h` or `python call.py --help`. 

To maintain backwards compatibility (for now), I have been able to successfully run the following two commands in my local environment and get the Julia engine to run locally (though not complete because I'm impatient) after copying scenario 1220 data to my local and updating `const.py` accordingly:
`python -u ./pyreisejl/utility/call.py 1220`
`python -u ./pyreisejl/utility/call.py 1220 5`

As an example of how the code can now be run:
`python ./pyreisejl/utility/call.py -s '2016-01-01 00:00:00' -e '2016-01-07 23:00:00' -int 24 -i /Users/annahurlimann/ScenarioData/test`

I've also included some additional checks/input validation:

- Enforcing that the interval passed in (-i, --interval) needs to be an integer
- A printed warning if the interval given doesn't evenly divide the start and end time given, which will presumably result in the exclusion of data at the end of given date range (WARNING: The interval you chose does not evenly divide your date range.)
- Requiring start_date, end_date, interval, input_dir if not using the PowerSimData notation (i.e. `python -u ./pyreisejl/utility/call.py -s '2016-01-01 00:00:00'` returns an WrongNumberOfArguments error).

```
usage: call.py [-h] [-s START_DATE] [-e END_DATE] [-int INTERVAL] [-i INPUT_DIR] [-o OUTPUT_DIR] [-t THREADS]
               [scenario_id] [powersim_threads]

Run REISE.jl simulation.

positional arguments:
  scenario_id           Scenario ID only if using PowerSimData.
  powersim_threads      Number of threads only if using PowerSimData.

optional arguments:
  -h, --help            show this help message and exit
  -s START_DATE, --start-date START_DATE
                        The start date for the simulation in format 'YYYY-MM-DD HH:MM:SS'
  -e END_DATE, --end-date END_DATE
                        The end date for the simulation in format 'YYYY-MM-DD HH:MM:SS'
  -int INTERVAL, --interval INTERVAL
                        The length of each interval in hours.
  -i INPUT_DIR, --input-dir INPUT_DIR
                        The directory containing the input data files. Required files are 'case.mat', 'demand.csv',
                        'hydro.csv', 'solar.csv', and 'wind.csv'.
  -o OUTPUT_DIR, --output-dir OUTPUT_DIR
                        The directory to store the results. This is optional and defaults to an output folder that will be
                        created in the input directory if it does not exist.
  -t THREADS, --threads THREADS
                        The number of threads to run the simulation with. This is optional and defaults to Auto.
```
### Where to Look

The code changed is all in `pyreise.utility.call`.

### Time to Review

15 min.