### PR TITLE
Add missing imports and run isort

### DIFF
--- a/pyreisejl/utility/call.py
+++ b/pyreisejl/utility/call.py
@@ -1,5 +1,5 @@
-import os
 import argparse
+import os
 from collections import OrderedDict
 from time import time
 
@@ -7,18 +7,18 @@ import numpy as np
 import pandas as pd
 
 from pyreisejl.utility import const
+from pyreisejl.utility.extract_data import extract_scenario
 from pyreisejl.utility.helpers import (
-    sec2hms,
-    WrongNumberOfArguments,
     InvalidDateArgument,
     InvalidInterval,
+    WrongNumberOfArguments,
     extract_date_limits,
-    validate_time_format,
-    validate_time_range,
     get_scenario,
     insert_in_file,
+    sec2hms,
+    validate_time_format,
+    validate_time_range,
 )
-from pyreisejl.utility.extract_data import extract_scenario
 
 
 def _record_scenario(scenario_id, runtime):
@@ -88,7 +88,6 @@ def launch_scenario(
     from julia.api import Julia
 
     jl = Julia(compiled_modules=False)
-    from julia import Main
     from julia import REISE
 
     start = time()

--- a/pyreisejl/utility/extract_data.py
+++ b/pyreisejl/utility/extract_data.py
@@ -1,11 +1,11 @@
-from collections import OrderedDict
+import argparse
 import datetime as dt
 import glob
 import os
+import re
 import subprocess
 import time
-import re
-import argparse
+from collections import OrderedDict
 
 import numpy as np
 import pandas as pd
@@ -14,11 +14,11 @@ from tqdm import tqdm
 
 from pyreisejl.utility import const
 from pyreisejl.utility.helpers import (
-    load_mat73,
     WrongNumberOfArguments,
-    validate_time_format,
     get_scenario,
     insert_in_file,
+    load_mat73,
+    validate_time_format,
 )
 
 

--- a/pyreisejl/utility/helpers.py
+++ b/pyreisejl/utility/helpers.py
@@ -1,7 +1,11 @@
+import os
+import re
+
 import h5py
 import numpy as np
 import pandas as pd
-import re
+
+from pyreisejl.utility import const
 
 
 class WrongNumberOfArguments(TypeError):

--- a/pyreisejl/utility/tests/test_extract_data.py
+++ b/pyreisejl/utility/tests/test_extract_data.py
@@ -3,10 +3,10 @@ import pandas as pd
 import pytest
 
 from pyreisejl.utility.extract_data import (
-    calculate_averaged_congestion,
-    _get_pkl_path,
     _cast_keys_as_lists,
+    _get_pkl_path,
     _update_outputs_labels,
+    calculate_averaged_congestion,
     result_num,
 )
 

--- a/pyreisejl/utility/tests/test_helpers.py
+++ b/pyreisejl/utility/tests/test_helpers.py
@@ -1,14 +1,15 @@
-import numpy as np
-import pytest
-import pandas as pd
 from io import StringIO
 
+import numpy as np
+import pandas as pd
+import pytest
+
 from pyreisejl.utility.helpers import (
-    sec2hms,
+    InvalidDateArgument,
     extract_date_limits,
+    sec2hms,
     validate_time_format,
     validate_time_range,
-    InvalidDateArgument,
 )
 
 


### PR DESCRIPTION
### Purpose
While debugging the docker prototype I noticed we didn't have some required import statements in `helpers.py`, so just adding those (`os` and `const`). I also ran isort, though it's not enforced here.

### Time to review
2 min