### PR TITLE
refactor: clean up thread specification in call.py

### DIFF
--- a/pyreisejl/utility/call.py
+++ b/pyreisejl/utility/call.py
@@ -227,6 +227,8 @@ if __name__ == "__main__":
         args.output_dir = const.OUTPUT_DIR
 
     if args.extract_data:
+        if not args.execute_dir:
+            args.execute_dir = os.path.join(args.input_dir, "output")
 
         extract_scenario(
             args.execute_dir,


### PR DESCRIPTION
### Purpose

Clean up the positional threads argument now that `PowerSimData` has been successfully migrated to use the threads flag, as well as fix bug regarding the default execute directory setting when using the non-`PowerSimData` entrypoint and the automatic data extraction flag.

### What is the code doing?

If an execute directory is not specified when doing automatic extraction, set the execute directory passed to `extract_data.py` as the `output` folder created by Julia.

### Where to Look

The code changed is in `call.py`.

### Time to Review

5 min.