### PR TITLE
bug: update keep matlab flag to work as documentation indicates

### DIFF
--- a/pyreisejl/utility/extract_data.py
+++ b/pyreisejl/utility/extract_data.py
@@ -409,7 +409,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-k",
         "--keep-matlab",
-        action="store_false",
+        action="store_true",
         help="If this flag is used, the result.mat files found in the "
         "execute directory will be kept instead of deleted.",
     )


### PR DESCRIPTION
### Purpose

Fix the default behavior of the `keep-matlab` flag to match the documentation.

### What is the code doing?

Currently if the `--keep-matlab` flag is used, the matlab files will be deleted and the default is to keep them. Switching this line will switch the default behavior so that these files are only kept if the flag is used.

### Where to Look

The code changed is in `extract_data.py`.

### Time to Review

5 min.