### PR TITLE
Doc: Add documentation for pyreisejl usage

### DIFF
--- a/pyreisejl/utility/call.py
+++ b/pyreisejl/utility/call.py
@@ -157,7 +157,7 @@ if __name__ == "__main__":
         "has finished running will be automatically extracted into .pkl files, "
         "and the result.mat files will be deleted. "
         "The extraction process can be memory intensive. "
-        "This is optional and defaults to False.",
+        "This is optional and defaults to False if the flag is omitted.",
     )
     parser.add_argument(
         "-o",

--- a/pyreisejl/utility/extract_data.py
+++ b/pyreisejl/utility/extract_data.py
@@ -407,7 +407,8 @@ if __name__ == "__main__":
         "--frequency",
         nargs="?",
         default="H",
-        help="The frequency of data points in the original profile csvs. "
+        help="The frequency of data points in the original profile csvs as a "
+        "Pandas frequency string. "
         "This is optional and defaults to an hour.",
     )
     parser.add_argument(


### PR DESCRIPTION
### Purpose
Document how to use 

### What is the code doing
The `README` now includes documentation around how to use `pyreisejl` (i.e. all the different possible flags) as well as some additional detail about what additional functions these python scripts provide.

It assumes that the user already has the proper setup for `Julia`, `Gurobi`, and `python`.

### Where to look
This is all in the `README`. No code has been touched.

### Time estimate
10min