### PR TITLE
Fix bug with single storage in extract

### DIFF
--- a/pyreisejl/utility/extract_data.py
+++ b/pyreisejl/utility/extract_data.py
@@ -243,10 +243,8 @@ def _get_outputs_from_converted(matfile):
         pass
 
     try:
-        if isinstance(case.Storage.UnitIdx, float):
-            num_storage = 1
-        else:
-            num_storage = len(case.Storage.UnitIdx)
+        storage_index = case.Storage.UnitIdx
+        num_storage = 1 if isinstance(storage_index, float) else len(storage_index)
         outputs_id["storage_pg"] = np.arange(num_storage)
         outputs_id["storage_e"] = np.arange(num_storage)
     except AttributeError:


### PR DESCRIPTION
### Purpose

Fix a bug, where results from a scenario with a single storage device could not be extracted.

### What is the code doing

Because of the way the matfile is read, arrays are reduced down to the lowest possible dimension. That means that the `case.Storage.UnitIdx` array, if it is length one, will be reduced from a 1D array to a float, which creates the following traceback:
```
Traceback (most recent call last):
  File "/home/bes/pcm/REISE.jl/pyreisejl/utility/extract_data.py", line 447, in <module>
    extract_scenario(
  File "/home/bes/pcm/REISE.jl/pyreisejl/utility/extract_data.py", line 333, in extract_scenario
    _update_outputs_labels(outputs, start_date, end_date, freq, matfile)
  File "/home/bes/pcm/REISE.jl/pyreisejl/utility/extract_data.py", line 285, in _update_outputs_labels
    outputs_id = _get_outputs_from_converted(matfile)
  File "/home/bes/pcm/REISE.jl/pyreisejl/utility/extract_data.py", line 246, in _get_outputs_from_converted
    num_storage = len(case.Storage.UnitIdx)
TypeError: object of type 'float' has no len()
```

Checking if it is a float before trying to call `len()` on it fixes this problem.

### Time to review

1 minute.