### PR TITLE
feat: enable differential pmin/pmax for DC lines

### DIFF
--- a/src/read.jl
+++ b/src/read.jl
@@ -27,12 +27,14 @@ function read_case(filepath)
         end
         case["dcline_from"] = convert(Array{Int,1}, mpc["dcline"][:,1])
         case["dcline_to"] = convert(Array{Int,1}, mpc["dcline"][:,2])
-        case["dcline_rating"] = mpc["dcline"][:,11]
+        case["dcline_pmin"] = mpc["dcline"][:,10]
+        case["dcline_pmax"] = mpc["dcline"][:,11]
     else
         case["dclineid"] = Int64[]
         case["dcline_from"] = Int64[]
         case["dcline_to"] = Int64[]
-        case["dcline_rating"] = Float64[]
+        case["dcline_pmin"] = Float64[]
+        case["dcline_pmax"] = Float64[]
     end
 
     # Buses

--- a/src/types.jl
+++ b/src/types.jl
@@ -11,7 +11,8 @@ Base.@kwdef struct Case
     dclineid::Array{Int64,1}
     dcline_from::Array{Int64,1}
     dcline_to::Array{Int64,1}
-    dcline_rating::Array{Float64,1}
+    dcline_pmin::Array{Float64,1}
+    dcline_pmax::Array{Float64,1}
 
     busid::Array{Int64,1}
     bus_demand::Array{Float64,1}


### PR DESCRIPTION
### Purpose

Interpret the Pmin and Pmax of DC lines, don't assume symmetry using just the Pmax.
Closes #87.

### What is the code doing

Walking through in order of execution:
- In **read.jl**, we look at the Pmin and Pmax columns of the DC line table, not just Pmax.
- In **types.jl**, we expect these new entries in the `Case` struct, which will get created based on what we got in **read.jl**.
- In **model.jl**:
  - In `_make_sets`, we change how we build the `noninf_branch_idx` set, since we now have `case.dcline_pmax` and `case.dcline_pmin` instead of `case.dcline_rating`. We also make sure that we do the replacement of `0` capacity -> `Inf` for AC lines only, not DC lines (since we may have a DCline with e.g. -100 Pmin and 0 Pmax).
  - In `-build_model`, we use the new `case.dcline_pmin` and `case.dcline_pmax` to create separate branch limits for + and -: `branch_pmin` and `branch_pmax` instead of the previous symmetric `branch_rating`. Then, we use these in building the constraints.

### Testing

This is provisional code. I've done some limited local testing (thanks to the command-line extract_data.py options from @ahurli, see https://github.com/Breakthrough-Energy/REISE.jl/pull/75), and this appears to work properly on symmetrical DC lines for existing scenarios. I still need to do testing for asymmetrical lines, but I'm reasonably confident in this code, since the changes are fairly straightforward.

### Time to review
15 minutes. The code changes are minor but meaningful.