### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.pytest_cache
+.tox


### PR DESCRIPTION
### Purpose
Prevent unnecessary files from being added to the docker build context, which would result in slower builds and potentially larger images.

### What it does
Ignore certain directories, we can add more as needed.

### Time to review
1 min