### PR TITLE
REST API to launch simulation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          python-version: [3.6, 3.7, 3.8]
+          python-version: [3.7, 3.8]
 
     name: Python ${{ matrix.python-version }}
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN wget -q https://julialang-s3.julialang.org/bin/linux/x64/1.5/julia-1.5.3-lin
 
 WORKDIR /build/gurobi_installer
 
-RUN wget -q https://packages.gurobi.com/9.1/gurobi9.1.0_linux64.tar.gz &&\
+RUN wget -q https://packages.gurobi.com/9.1/gurobi9.1.0_linux64.tar.gz && \
     tar -xf gurobi9.1.0_linux64.tar.gz -C /usr/share
 
 ENV PATH="$PATH:/usr/share/julia-1.5.3/bin" \
@@ -15,16 +15,14 @@ ENV PATH="$PATH:/usr/share/julia-1.5.3/bin" \
     GUROBI_HOME='/usr/share/gurobi910/linux64' \
     GRB_LICENSE_FILE='/usr/share/gurobi_license/gurobi.lic' \
     JULIA_PROJECT='/app' \
-    PYTHONPATH=/app/pyreisejl:${PYTHONPATH}
+    PYTHONPATH=/app/pyreisejl:${PYTHONPATH} \
+    FLASK_APP=pyreisejl/utility/app.py
 
 WORKDIR /app
 COPY . .
 
-RUN julia -e 'using Pkg; Pkg.activate("."); Pkg.instantiate(), using REISE' &&\
+RUN julia -e 'using Pkg; Pkg.activate("."); Pkg.instantiate(), using REISE' && \
     pip install -r requirements.txt
 
 
-
-
-WORKDIR /app
-ENTRYPOINT ["bash"]
+CMD ["flask", "run", "--host", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ To run the Docker image, you will need to mount two volumes; one containing the
 engine. 
 
 ```bash
-docker run -i -v /LOCAL/PATH/TO/GUROBI.LIC:/usr/share/gurobi_license -v /LOCAL/PATH/TO/DATA:/usr/share/data reisejl bash
+docker run -it -v /LOCAL/PATH/TO/GUROBI.LIC:/usr/share/gurobi_license -v /LOCAL/PATH/TO/DATA:/usr/share/data reisejl bash
 ```
 
 The following command will start a bash shell session within the container,

--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ To run the Docker image, you will need to mount two volumes; one containing the
 engine. 
 
 ```
-docker run -it -v /LOCAL/PATH/TO/GUROBI.LIC:/usr/share/gurobi_license -v /LOCAL/PATH/TO/DATA:/usr/share/data reisejl
+docker run -i -v /LOCAL/PATH/TO/GUROBI.LIC:/usr/share/gurobi_license -v /LOCAL/PATH/TO/DATA:/usr/share/data reisejl bash
 ```
 
 The following command will start a bash shell session within the container,

--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ The easiest way to setup this engine is within a Docker image. Note, however, th
 
 There is an included `Dockerfile` that can be used to build the Docker image. With the Docker daemon installed and running, navigate to the `REISE.jl` folder containing the `Dockerfile` and build the image:
 
-```
+```bash
 docker build . -t reisejl
 ```
 
@@ -454,14 +454,14 @@ To run the Docker image, you will need to mount two volumes; one containing the
 `Gurobi` license file and another containing the necessary input files for the
 engine. 
 
-```
+```bash
 docker run -i -v /LOCAL/PATH/TO/GUROBI.LIC:/usr/share/gurobi_license -v /LOCAL/PATH/TO/DATA:/usr/share/data reisejl bash
 ```
 
 The following command will start a bash shell session within the container,
 using the `python` commands described above.
 
-```
+```bash
 python pyreisejl/utility/call.py -s '2016-01-01' -e '2016-01-07' -int 24 -i '/usr/share/data'
 ```
 

--- a/pyreisejl/utility/app.py
+++ b/pyreisejl/utility/app.py
@@ -27,14 +27,11 @@ def get_script_path():
 
 @app.route("/launch/<int:scenario_id>", methods=["POST"])
 def launch_simulation(scenario_id):
-    if state.is_running(scenario_id):
-        return jsonify("Scenario is already in progress")
-
     cmd_call = ["python3", "-u", get_script_path(), str(scenario_id)]
     proc = Popen(cmd_call, stdout=PIPE, stderr=PIPE)
 
     info = ScenarioState(scenario_id, proc)
-    state.add(scenario_id, info)
+    state.add(info)
     return jsonify(info.as_dict())
 
 
@@ -45,7 +42,8 @@ def list_ongoing():
 
 @app.route("/status/<int:scenario_id>")
 def get_status(scenario_id):
-    return jsonify(state.get(scenario_id))
+    entry = state.get(scenario_id)
+    return jsonify(entry), 200 if entry is not None else 404
 
 
 if __name__ == "__main__":

--- a/pyreisejl/utility/app.py
+++ b/pyreisejl/utility/app.py
@@ -3,7 +3,7 @@ from subprocess import PIPE, Popen
 
 from flask import Flask, jsonify
 
-from pyreisejl.utility.state import ApplicationState, ScenarioState
+from pyreisejl.utility.state import ApplicationState, SimulationState
 
 app = Flask(__name__)
 
@@ -30,7 +30,7 @@ def launch_simulation(scenario_id):
     cmd_call = ["python3", "-u", get_script_path(), str(scenario_id)]
     proc = Popen(cmd_call, stdout=PIPE, stderr=PIPE, start_new_session=True)
 
-    entry = ScenarioState(scenario_id, proc)
+    entry = SimulationState(scenario_id, proc)
     state.add(entry)
     return jsonify(entry.as_dict())
 

--- a/pyreisejl/utility/app.py
+++ b/pyreisejl/utility/app.py
@@ -28,7 +28,7 @@ def get_script_path():
 
 @app.route("/launch/<int:scenario_id>", methods=["POST"])
 def launch_simulation(scenario_id):
-    cmd_call = ["python3", "-u", get_script_path(), str(scenario_id)]
+    cmd_call = ["python3", "-u", get_script_path(), str(scenario_id), "--extract-data"]
     threads = request.args.get("threads", None)
 
     if threads is not None:

--- a/pyreisejl/utility/app.py
+++ b/pyreisejl/utility/app.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+from subprocess import Popen
+
+from flask import Flask, jsonify
+
+from pyreisejl.utility.helpers import get_scenario_status
+
+app = Flask(__name__)
+
+
+"""
+Example request:
+
+curl -XPOST http://localhost:5000/launch/1234
+curl http://localhost:5000/status/1234
+"""
+
+
+# scenario_id -> pid
+ongoing = {}
+
+
+def get_script_path():
+    script_dir = Path(__file__).parent.absolute()
+    path_to_script = Path(script_dir, "call.py")
+    return str(path_to_script)
+
+
+# TODO pipe stdout to in memory object
+@app.route("/launch/<scenario_id>", methods=["POST"])
+def launch_simulation(scenario_id):
+    cmd_call = ["python3", "-u", get_script_path(), scenario_id]
+    pid = Popen(cmd_call).pid
+    ongoing[scenario_id] = pid
+    return jsonify({"pid": pid})
+
+
+# TODO remove pid when process complete
+@app.route("/list")
+def list_ongoing():
+    return jsonify(ongoing)
+
+
+# TODO append details from redirected io
+@app.route("/status/<int:scenario_id>")
+def get_status(scenario_id):
+    status = get_scenario_status(scenario_id)
+    return jsonify(status)
+
+
+if __name__ == "__main__":
+    app.run(port=5000, debug=True)

--- a/pyreisejl/utility/app.py
+++ b/pyreisejl/utility/app.py
@@ -28,7 +28,7 @@ def get_script_path():
 @app.route("/launch/<int:scenario_id>", methods=["POST"])
 def launch_simulation(scenario_id):
     cmd_call = ["python3", "-u", get_script_path(), str(scenario_id)]
-    proc = Popen(cmd_call, stdout=PIPE, stderr=PIPE)
+    proc = Popen(cmd_call, stdout=PIPE, stderr=PIPE, start_new_session=True)
 
     entry = ScenarioState(scenario_id, proc)
     state.add(entry)

--- a/pyreisejl/utility/app.py
+++ b/pyreisejl/utility/app.py
@@ -27,6 +27,9 @@ def get_script_path():
 
 @app.route("/launch/<int:scenario_id>", methods=["POST"])
 def launch_simulation(scenario_id):
+    if state.is_running(scenario_id):
+        return jsonify("Scenario is already in progress")
+
     cmd_call = ["python3", "-u", get_script_path(), str(scenario_id)]
     proc = Popen(cmd_call, stdout=PIPE, stderr=PIPE)
 

--- a/pyreisejl/utility/app.py
+++ b/pyreisejl/utility/app.py
@@ -30,9 +30,9 @@ def launch_simulation(scenario_id):
     cmd_call = ["python3", "-u", get_script_path(), str(scenario_id)]
     proc = Popen(cmd_call, stdout=PIPE, stderr=PIPE)
 
-    info = ScenarioState(scenario_id, proc)
-    state.add(info)
-    return jsonify(info.as_dict())
+    entry = ScenarioState(scenario_id, proc)
+    state.add(entry)
+    return jsonify(entry.as_dict())
 
 
 @app.route("/list")

--- a/pyreisejl/utility/call.py
+++ b/pyreisejl/utility/call.py
@@ -89,6 +89,18 @@ def launch_scenario(
     Julia(compiled_modules=False)
     from julia import REISE
 
+    print("Validation complete! Launching scenario with parameters:")
+    print(
+        {
+            "interval": interval,
+            "n_interval": n_interval,
+            "start_index": start_index,
+            "input_dir": input_dir,
+            "execute_dir": execute_dir,
+            "threads": threads,
+        }
+    )
+
     start = time()
     REISE.run_scenario(
         interval=interval,

--- a/pyreisejl/utility/call.py
+++ b/pyreisejl/utility/call.py
@@ -108,7 +108,6 @@ def launch_scenario(
 
 
 def main(args):
-
     # Get scenario info if using PowerSimData
     if args.scenario_id:
         scenario_args = get_scenario(args.scenario_id)
@@ -162,4 +161,10 @@ def main(args):
 
 
 if __name__ == "__main__":
-    main(parser.parse_call_args())
+    args = parser.parse_call_args()
+    try:
+        main(args)
+    except Exception as ex:
+        print(ex)  # sent to redirected stdout/stderr
+        if args.scenario_id:
+            insert_in_file(const.EXECUTE_LIST, args.scenario_id, "status", "failed")

--- a/pyreisejl/utility/call.py
+++ b/pyreisejl/utility/call.py
@@ -107,8 +107,7 @@ def launch_scenario(
     return runtime
 
 
-if __name__ == "__main__":
-    args = parser.parse_call_args()
+def main(args):
 
     # Get scenario info if using PowerSimData
     if args.scenario_id:
@@ -160,3 +159,7 @@ if __name__ == "__main__":
             mat_dir=args.matlab_dir,
             keep_mat=args.keep_matlab,
         )
+
+
+if __name__ == "__main__":
+    main(parser.parse_call_args())

--- a/pyreisejl/utility/const.py
+++ b/pyreisejl/utility/const.py
@@ -4,6 +4,8 @@ DATA_ROOT_DIR = "/mnt/bes/pcm"
 
 SCENARIO_LIST = posixpath.join(DATA_ROOT_DIR, "ScenarioList.csv")
 EXECUTE_LIST = posixpath.join(DATA_ROOT_DIR, "ExecuteList.csv")
+# SCENARIO_LIST = os.path.join("~/ScenarioData", "ScenarioList.csv")
+# EXECUTE_LIST = os.path.join("~/ScenarioData", "ExecuteList.csv")
 EXECUTE_DIR = posixpath.join(DATA_ROOT_DIR, "tmp")
 INPUT_DIR = posixpath.join(DATA_ROOT_DIR, "data", "input")
 OUTPUT_DIR = posixpath.join(DATA_ROOT_DIR, "data", "output")

--- a/pyreisejl/utility/const.py
+++ b/pyreisejl/utility/const.py
@@ -4,8 +4,6 @@ DATA_ROOT_DIR = "/mnt/bes/pcm"
 
 SCENARIO_LIST = posixpath.join(DATA_ROOT_DIR, "ScenarioList.csv")
 EXECUTE_LIST = posixpath.join(DATA_ROOT_DIR, "ExecuteList.csv")
-# SCENARIO_LIST = os.path.join("~/ScenarioData", "ScenarioList.csv")
-# EXECUTE_LIST = os.path.join("~/ScenarioData", "ExecuteList.csv")
 EXECUTE_DIR = posixpath.join(DATA_ROOT_DIR, "tmp")
 INPUT_DIR = posixpath.join(DATA_ROOT_DIR, "data", "input")
 OUTPUT_DIR = posixpath.join(DATA_ROOT_DIR, "data", "output")

--- a/pyreisejl/utility/extract_data.py
+++ b/pyreisejl/utility/extract_data.py
@@ -201,6 +201,7 @@ def build_log(mat_results, costs, output_dir, scenario_id=None):
     # Create log name
     log_filename = scenario_id + "_log.csv" if scenario_id else "log.csv"
 
+    os.makedirs(output_dir, exist_ok=True)
     with open(os.path.join(output_dir, log_filename), "w") as log:
         # Write headers
         log.write(",cost,filesize,write_datetime\n")

--- a/pyreisejl/utility/helpers.py
+++ b/pyreisejl/utility/helpers.py
@@ -213,3 +213,5 @@ def get_scenario_status(scenario_id):
         return table.loc[scenario_id, "status"]
     except KeyError:
         return None
+    except Exception:
+        print("Failed to read csv")

--- a/pyreisejl/utility/helpers.py
+++ b/pyreisejl/utility/helpers.py
@@ -205,3 +205,8 @@ def insert_in_file(filename, scenario_id, column_name, column_value):
     table.set_index("id", inplace=True)
     table.loc[str(scenario_id), column_name] = column_value
     table.to_csv(filename)
+
+
+def get_scenario_status(scenario_id):
+    table = pd.read_csv(const.EXECUTE_LIST, index_col="id")
+    return table.loc[scenario_id, "status"]

--- a/pyreisejl/utility/helpers.py
+++ b/pyreisejl/utility/helpers.py
@@ -208,5 +208,8 @@ def insert_in_file(filename, scenario_id, column_name, column_value):
 
 
 def get_scenario_status(scenario_id):
-    table = pd.read_csv(const.EXECUTE_LIST, index_col="id")
-    return table.loc[scenario_id, "status"]
+    try:
+        table = pd.read_csv(const.EXECUTE_LIST, index_col="id")
+        return table.loc[scenario_id, "status"]
+    except KeyError:
+        return None

--- a/pyreisejl/utility/helpers.py
+++ b/pyreisejl/utility/helpers.py
@@ -208,10 +208,16 @@ def insert_in_file(filename, scenario_id, column_name, column_value):
 
 
 def get_scenario_status(scenario_id):
+    """Get the status of the scenario.
+
+    :param int scenario_id: scenario index
+    :return: (*str*) -- the status, e.g. running, finished, etc, or None
+    """
     try:
         table = pd.read_csv(const.EXECUTE_LIST, index_col="id")
         return table.loc[scenario_id, "status"]
     except KeyError:
         return None
-    except Exception:
-        print("Failed to read csv")
+    except Exception as ex:
+        print("Failed to read execute list. It's likely the file does not exist.")
+        print(f"Exception message: {ex}")

--- a/pyreisejl/utility/state.py
+++ b/pyreisejl/utility/state.py
@@ -30,7 +30,15 @@ class ApplicationState:
         self.ongoing[int(scenario_id)] = state
 
     def get(self, scenario_id):
+        if scenario_id not in self.ongoing:
+            return None
         return self.ongoing[scenario_id].as_dict()
+
+    def is_running(self, scenario_id):
+        entry = self.get(scenario_id)
+        if entry is not None:
+            return entry["status"] == "running"
+        return False
 
     def as_dict(self):
         return {k: v.as_dict() for k, v in self.ongoing.items()}

--- a/pyreisejl/utility/state.py
+++ b/pyreisejl/utility/state.py
@@ -24,7 +24,7 @@ class ScenarioState:
         """Return custom dict which omits the process attribute which is not
         serializable.
 
-        :return (**dict**) -- dict of the instance attributes
+        :return: (*dict*) -- dict of the instance attributes
         """
         self._refresh()
         return {k: v for k, v in self.__dict__.items() if k != "proc"}
@@ -45,7 +45,7 @@ class ApplicationState:
         """Get the latest information for a scenario if it is present
 
         :param int scenario_id: id of the scenario
-        :return (**dict**) -- a dict containing values from the ScenarioState
+        :return: (*dict*) -- a dict containing values from the ScenarioState
         """
         if scenario_id not in self.ongoing:
             return None
@@ -55,6 +55,6 @@ class ApplicationState:
         """Custom dict implementation which utilizes the similar method from
         ScenarioState
 
-        :return (**dict**) -- dict of the instance attributes
+        :return: (*dict*) -- dict of the instance attributes
         """
         return {k: v.as_dict() for k, v in self.ongoing.items()}

--- a/pyreisejl/utility/state.py
+++ b/pyreisejl/utility/state.py
@@ -26,19 +26,13 @@ class ScenarioState:
 class ApplicationState:
     ongoing: Dict[int, ScenarioState] = field(default_factory=dict)
 
-    def add(self, scenario_id, state):
-        self.ongoing[int(scenario_id)] = state
+    def add(self, state):
+        self.ongoing[int(state.scenario_id)] = state
 
     def get(self, scenario_id):
         if scenario_id not in self.ongoing:
             return None
         return self.ongoing[scenario_id].as_dict()
-
-    def is_running(self, scenario_id):
-        entry = self.get(scenario_id)
-        if entry is not None:
-            return entry["status"] == "running"
-        return False
 
     def as_dict(self):
         return {k: v.as_dict() for k, v in self.ongoing.items()}

--- a/pyreisejl/utility/state.py
+++ b/pyreisejl/utility/state.py
@@ -5,7 +5,7 @@ from pyreisejl.utility.helpers import get_scenario_status
 
 
 @dataclass
-class ScenarioState:
+class SimulationState:
     scenario_id: int
     proc: Any = field(default=None, repr=False, compare=False, hash=False)
     output: str = field(default="", repr=False, compare=False, hash=False)
@@ -32,12 +32,12 @@ class ScenarioState:
 
 @dataclass
 class ApplicationState:
-    ongoing: Dict[int, ScenarioState] = field(default_factory=dict)
+    ongoing: Dict[int, SimulationState] = field(default_factory=dict)
 
     def add(self, entry):
         """Add entry for scenario to current state
 
-        :param ScenarioState entry: object to track a given scenario
+        :param SimulationState entry: object to track a given scenario
         """
         self.ongoing[int(entry.scenario_id)] = entry
 
@@ -53,7 +53,7 @@ class ApplicationState:
 
     def as_dict(self):
         """Custom dict implementation which utilizes the similar method from
-        ScenarioState
+        SimulationState
 
         :return: (*dict*) -- dict of the instance attributes
         """

--- a/pyreisejl/utility/state.py
+++ b/pyreisejl/utility/state.py
@@ -1,0 +1,36 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+from pyreisejl.utility.helpers import get_scenario_status
+
+
+@dataclass
+class ScenarioState:
+    scenario_id: int
+    proc: Any = field(default=None, repr=False, compare=False, hash=False)
+    output: str = field(default="", repr=False, compare=False, hash=False)
+    errors: str = field(default="", repr=False, compare=False, hash=False)
+    status: str = None
+
+    def refresh(self):
+        self.status = get_scenario_status(self.scenario_id)
+        self.output += self.proc.stdout.read().decode()
+        self.errors += self.proc.stderr.read().decode()
+
+    def as_dict(self):
+        self.refresh()
+        return {k: v for k, v in self.__dict__.items() if k != "proc"}
+
+
+@dataclass
+class ApplicationState:
+    ongoing: Dict[int, ScenarioState] = field(default_factory=dict)
+
+    def add(self, scenario_id, state):
+        self.ongoing[int(scenario_id)] = state
+
+    def get(self, scenario_id):
+        return self.ongoing[scenario_id].as_dict()
+
+    def as_dict(self):
+        return {k: v.as_dict() for k, v in self.ongoing.items()}

--- a/pyreisejl/utility/tests/__init__.py
+++ b/pyreisejl/utility/tests/__init__.py
@@ -1,1 +1,0 @@
-__all__ = ["test_extract_data"]

--- a/pyreisejl/utility/tests/test_state.py
+++ b/pyreisejl/utility/tests/test_state.py
@@ -1,0 +1,41 @@
+from pyreisejl.utility.state import ApplicationState, ScenarioState
+
+
+class FakeIOStream:
+    def __init__(self):
+        self.counter = 0
+
+    def read(self):
+        self.counter += 1
+        return bytes(str(self.counter).encode())
+
+
+class FakeProcess:
+    def __init__(self):
+        self.stdout = FakeIOStream()
+        self.stderr = FakeIOStream()
+
+
+def test_scenario_state_refresh():
+    entry = ScenarioState(1234, FakeProcess())
+    entry.as_dict()
+    assert entry.output == "1"
+    assert entry.errors == "1"
+    entry.as_dict()
+    assert entry.output == "12"
+    assert entry.errors == "12"
+
+
+def test_scenario_state_serializable():
+    entry = ScenarioState(1234, FakeProcess())
+    assert "proc" not in entry.as_dict().keys()
+
+
+def test_app_state_get():
+    state = ApplicationState()
+    assert len(state.ongoing) == 0
+
+    entry = ScenarioState(1234, FakeProcess())
+    state.add(entry)
+    assert len(state.ongoing) == 1
+    assert state.get(1234) is not None

--- a/pyreisejl/utility/tests/test_state.py
+++ b/pyreisejl/utility/tests/test_state.py
@@ -1,4 +1,4 @@
-from pyreisejl.utility.state import ApplicationState, ScenarioState
+from pyreisejl.utility.state import ApplicationState, SimulationState
 
 
 class FakeIOStream:
@@ -17,7 +17,7 @@ class FakeProcess:
 
 
 def test_scenario_state_refresh():
-    entry = ScenarioState(1234, FakeProcess())
+    entry = SimulationState(1234, FakeProcess())
     entry.as_dict()
     assert entry.output == "1"
     assert entry.errors == "1"
@@ -27,7 +27,7 @@ def test_scenario_state_refresh():
 
 
 def test_scenario_state_serializable():
-    entry = ScenarioState(1234, FakeProcess())
+    entry = SimulationState(1234, FakeProcess())
     assert "proc" not in entry.as_dict().keys()
 
 
@@ -35,7 +35,7 @@ def test_app_state_get():
     state = ApplicationState()
     assert len(state.ongoing) == 0
 
-    entry = ScenarioState(1234, FakeProcess())
+    entry = SimulationState(1234, FakeProcess())
     state.add(entry)
     assert len(state.ongoing) == 1
     assert state.get(1234) is not None

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pandas~=1.1.3
 scipy~=1.2
 tqdm~=4.29.1
 pytest~=6.1.1
+Flask~=1.1.2


### PR DESCRIPTION
### Purpose
Enable powersimdata to communicate with the reisejl container over http, which along with using a shared volume will eliminate the need for ssh within a container based installation. 

### What it does
Exposes an api endpoint as an alternative way to invoke `call.py` . This can be called by powersimdata using only the hostname of the container and the scenario id (see the sample curl command in `app.py`). Note, we could optionally use this on the server but that's not the primary goal here. The `state.py` module has some helper classes to keep track of which scenarios have been started during the lifetime of the flask app and provide a convenient way to query them (returning the status plus stdout/stderr). I also added a "failed" status for the execute list if any exception occurs during the process. 

Minor details - the docker image will now run flask by default so I updated the readme command to override that with bash. Will add more details to the readme once the necessary support is added to powersimdata. For now, this can be run using either `flask run` on the command line or `docker run -p 5000:5000 reisejl` after building the image.

### Testing
There are some unit tests for the state classes and I've done some manual testing by setting the values in `const.py` to my local directory and mocking out the `main` method with test output. 

Update: I've tested this locally in a container by running a simulation with the cloud license and extracting the results

### Time to review
60 mins - guessing this will be new for a good chuck of people, so I can provide more details or talk through any parts that are of interest