### PR TITLE
refactor: accept Suboptimal if load shed is enabled

### DIFF
--- a/src/loop.jl
+++ b/src/loop.jl
@@ -118,6 +118,12 @@ function interval_loop(env::Gurobi.Env, model_kwargs::Dict,
                 f = JuMP.objective_value(m)
                 results = get_results(f, voi, model_kwargs["case"])
                 break
+            elseif ((status == JuMP.MOI.LOCALLY_SOLVED)
+                    & ("load_shed_enabled" in keys(model_kwargs)))
+                # if load shedding is enabled, we'll accept 'suboptimal'
+                f = JuMP.objective_value(m)
+                results = get_results(f, voi, model_kwargs["case"])
+                break
             elseif ((status in numeric_statuses)
                     & !("BarHomogeneous" in keys(solver_kwargs)))
                 # if BarHomogeneous is not enabled, enable it and re-build


### PR DESCRIPTION
### Purpose

Avoid termination on Suboptimal result code from Gurobi if load shed is already enabled.

### Rationale
copied from Slack:

"An update on our suboptimal results: since we've updated to Gurobi 9.1.0, we've been noticing more 'suboptimal' solver termination statuses. Luckily, we've been logging the stdout of the runs, so with some automated parsing of the log files, we can see how the values of the objective functions that the solver returns changes with different problem/solver settings.
Over 126 scenarios, we logged 346 'suboptimal' returns. Only 9 scenarios did not have any suboptimal returns! The corrective actions taken fall into a few main buckets:
- enable Gurobi's BarHomogeneous setting
- rebuild the problem with load shedding enabled
- manually restart the scenario run, disabling the ramp rate limits for the first interval

After some combination of corrective actions was taken, an 'optimal' return was achieved, and we can calculate the relative difference between this 'ultimate' objective function value and the initially found (suboptimal) solution. In 295 of these 346 events, the relative difference was <0.1%.
In the 51 events with significant differences, 45 of them were resolved after enabling load shedding: either as the first and only step, or after enabling BarHomogeneous and then enabling load shedding. In the 6 with more complicated corrective actions:
- 5 involved a 4-step process of: rebuilding with load shed, restarting, enabling BarHomogenous, and enabling load shed
- 1 involved several restarts with differing numbers of threads until we got an optimal solution (sounds silly but it worked!)

In the cases with significant differences, the average difference between the initial solution and the final one was 19%. That's bad! BUT: for _**all**_ of these cases, the value of the objective function found after the first time load shedding was enabled (whether this solution was also suboptimal or not) was within 0.1% of the ultimate solution!
_**SO**_: based on the 125 USA scenarios over the last month of using Gurobi 9.1, it seems that _as long as load shedding is enabled_ for an interval, then suboptimal results can be accepted, because any further corrective actions (i.e. restarting the scenario to relax the generator ramp rate limits) will not meaningfully affect the found objective function value. If load shedding _is not already enabled_, it should be, because it is very likely that enabling load shedding will lead to a very different result."

### Testing
No more early terminations have been seen in several dozen scenarios with this code checked out.

### Time to review

10 minutes.