### PR TITLE
feat: add flexibility for solvers besides Gurobi

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,14 @@ REISE.run_scenario(;
     interval=24, n_interval=3, start_index=1, outputfolder="output",
     inputfolder=pwd(), num_segments=3)
 ```
+If another solver is desired, it can be passed via the `optimizer_factory` argument, e.g.:
+```julia
+import GLPK
+REISE.run_scenario(;
+    interval=24, n_interval=3, start_index=1, outputfolder="output",
+    inputfolder=pwd(), optimizer_factory=GLPK.Optimizer)
+```
+Be sure to pass the factory itself (e.g. `GLPK.Optimizer`) rather than an instance (e.g. `GLPK.Optimizer()`). See the [JuMP.Model documentation] for more information.
 
 ## Usage (Python)
 
@@ -665,3 +673,4 @@ Penalty for ending the interval with less stored energy than the start, or rewar
 
 [Gurobi.jl]: https://github.com/JuliaOpt/Gurobi.jl#installation
 [Julia Package Manager]: https://julialang.github.io/Pkg.jl/v1/managing-packages/
+[JuMP.Model documentation]: https://jump.dev/JuMP.jl/stable/solvers/#JuMP.Model-Tuple{Any}


### PR DESCRIPTION
### Purpose

Add flexibility for solvers besides Gurobi. Closes #97 

### What is the code doing

In **loop.jl**:
- we add a function `symbolize` (unrelated refactor to clean up the manual conversion from a Dict of strings to a NamedTuple within `interval_loop`).
- we add a function `new_model`, which returns a new JuMP model. This function can take either a Gurobi environment, or an optimizer factory.
- in `interval_loop`:
  - we change the inputs, so that we can pass either a Gurobi environment or any other optimizer factory.
  - instead of hardcoding that we create a new model from the passed Gurobi environment, we use the `new_model` function.
  - we only activate `BarHomogeneous if we are using Gurobi
  - we use our new `symbolize` function for succinctness (unrelated)

In **REISE.jl**, we add a new optional input `optimizer_factory`
- if this is not given, we start a Gurobi environment, just like before. We also put Gurobi-specific stuff within `if` block.
- if this is given, we pass this to `interval_loop`

### Testing

This has been tested with both `Clp.jl` and `GLPK.jl`, as well as in the default mode with Gurobi.

with GLPK.jl installed:
```julia
import REISE
import GLPK
REISE.run_scenario(; interval=1, n_interval=3, start_index=1, inputfolder="path_to_your_local_input_files", optimizer_factory=GLPK.Optimizer)
```

with Clp.jl installed:
```julia
import REISE
import Clp
REISE.run_scenario(; interval=1, n_interval=3, start_index=1, inputfolder="path_to_your_local_input_files", optimizer_factory=Clp.Optimizer)
```

### Time to review

30 minutes.