### PR TITLE
fix: remove zero-padding for storage gen table

### DIFF
--- a/src/save.jl
+++ b/src/save.jl
@@ -31,8 +31,8 @@ function save_input_mat(case::Case, storage::Storage, inputfolder::String,
         num_storage = size(storage.gen, 1)
         # Add fuel types for storage 'generators'. ESS = energy storage system
         mpc["genfuel"] = [mpc["genfuel"] ; repeat(["ess"], num_storage)]
-        # Save storage modifications to gen table (with extra zeros for MUs)
-        mpc["gen"] = [mpc["gen"] ; hcat(storage.gen, zeros(num_storage, 4))]
+        # Save storage modifications to gen table
+        mpc["gen"] = [mpc["gen"] ; storage.gen]
         # Save storage modifications to gencost
         #@show case.gencost[:, gencost_MODEL]
         segment_indices = findall(case.gencost[:, gencost_MODEL] .== 1)


### PR DESCRIPTION
### Purpose

Fix bug for storage introduced in https://github.com/Breakthrough-Energy/PowerSimData/pull/363.

### What is the code doing

Previously, we had specified only the 21 'input' columns of the `mpc.gen` format, not the 'output' ones (`mu_Pmin`, `mu_Pmax`, `mu_Qmin`, `mu_Qmax`). This may have been an artifact of the MATPOWER/MOST days. Therefore, we had to zero-pad these columns to merge the storage gen table with the main gen table.

In https://github.com/Breakthrough-Energy/PowerSimData/pull/363, we start adding these columns in the **case_storage.mat** files that we produce, so now the zero-padding creates a dimension mismatch which causes an error in `save_input_mat`. We remove the zero-padding and now everything works again.

### Testing

Before, scenario 2124 fails with error:
```
ERROR: ArgumentError: number of columns of each array must match (got (25, 29))
Stacktrace:
 [1] _typed_vcat(::Type{Float64}, ::Tuple{Array{Float64,2},Array{Float64,2}}) at ./abstractarray.jl:1439
 [2] typed_vcat at ./abstractarray.jl:1453 [inlined]
 [3] vcat(::Array{Float64,2}, ::Array{Float64,2}) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/SparseArrays/src/sparsevector.jl:1077
 [4] save_input_mat(::REISE.Case, ::REISE.Storage, ::String, ::String) at /home/bes/pcm/REISE.jl/src/save.jl:35
 [5] run_scenario(; num_segments::Int64, interval::Int64, n_interval::Int64, start_index::Int64, inputfolder::String, outputfolder::Nothing, threads::Nothing) at /home/bes/pcm/REISE.jl/src/REISE.jl:54
 [6] top-level scope at REPL[2]:1
```
After, the scenario runs properly.

### Time to review

5 minutes.