### PR TITLE
feat: implement more storage features

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -275,7 +275,7 @@ function _build_model(m::JuMP.Model; case::Case, storage::Storage,
         JuMP.@constraint(m,
             soc_tracking[i in 1:sets.num_storage, h in 1:(num_hour-1)],
             storage_soc[i, h+1] == (
-                storage_soc[i, h]
+                storage_soc[i, h] * (1 - storage.sd_table.LossFactor[i])
                 + storage.sd_table.InEff[i] * storage_chg[i, h+1]
                 - (1 / storage.sd_table.OutEff[i]) * storage_dis[i, h+1]),
             container=Array)

--- a/src/model.jl
+++ b/src/model.jl
@@ -287,6 +287,16 @@ function _build_model(m::JuMP.Model; case::Case, storage::Storage,
                 + storage.sd_table.InEff[i] * storage_chg[i, 1]
                 - (1 / storage.sd_table.OutEff[i]) * storage_dis[i, 1]),
             container=Array)
+        println("storage final_soc_min: ", Dates.now())
+        JuMP.@constraint(m,
+            soc_terminal_min[i in 1:sets.num_storage],
+            storage_soc[i, num_hour] >= storage.sd_table.ExpectedTerminalStorageMin[i],
+            container=Array)
+        println("storage final_soc_max: ", Dates.now())
+        JuMP.@constraint(m,
+            soc_terminal_max[i in 1:sets.num_storage],
+            storage_soc[i, num_hour] <= storage.sd_table.ExpectedTerminalStorageMax[i],
+            container=Array)
     end
 
     noninf_ramp_idx = findall(case.gen_ramp30 .!= Inf)

--- a/src/model.jl
+++ b/src/model.jl
@@ -47,7 +47,7 @@ function _make_bus_demand(case::Case, start_index::Int, end_index::Int)::Matrix
     bus_df = DataFrames.DataFrame(
         name=case.busid, load=case.bus_demand, zone=case.bus_zone)
     zone_demand = DataFrames.combine(
-		DataFrames.groupby(bus_df, :zone), :load => sum)
+        DataFrames.groupby(bus_df, :zone), :load => sum)
     zone_list = sort(collect(Set(case.bus_zone)))
     num_zones = length(zone_list)
     zone_idx = 1:num_zones


### PR DESCRIPTION
### Purpose

Interpret and use all of the storage features that we specify.

### What is the code doing

- We include self-discharge losses on the state of charge across all hours
- We constrain the ending state of charge

### Testing

The `LossFactor` parameter has been tested in scenario 2129, which is identical to scenario 2124 besides adding `Lossfactor = 0.05` for each storage device. 100% efficiency in both cases
- Scenario 2124: 10,755,668 MWh charged, 10,769,628 MWh discharged. (making use of a small amount of 'free' energy at the start of the first interval). Storage is sometimes 'held' for a while.
![image](https://user-images.githubusercontent.com/7348392/106322630-f85e2500-622a-11eb-9beb-1dccdd1e9ea6.png)

- Scenario 2129: 11,879,526 MWh charged, 8,883,825 MWh discharged. Energy is discharged very soon after it is charged, it is not typically 'held' because this is wasteful.
![image](https://user-images.githubusercontent.com/7348392/106322773-30656800-622b-11eb-91a8-d0b875c30e7e.png)

The terminal storage parameters were tested in scenario 2128, but with the wrong sign on the TerminalMax constraint, so it was constrained to be 60%-100% at the end of each interval, rather than 40-60%. This can be confirmed by checking `storage_e[storage_e.index.hour == 23].min()` and `storage_e[storage_e.index.hour == 23].max()`, and comparing to scenario 2124 (the same, except for these terminal storage constraints). This is being re-tested in scenario 2134.

### Time to review

15 minutes.