### PR TITLE
refactor: remove Gurobi requirement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ENV PATH="$PATH:/usr/share/julia-1.5.3/bin" \
 WORKDIR /app
 COPY . .
 
-RUN julia -e 'using Pkg; Pkg.activate("."); Pkg.instantiate(), using REISE' && \
+RUN julia -e 'using Pkg; Pkg.activate("."); Pkg.instantiate(); Pkg.add("Gurobi"); import Gurobi; using REISE' && \
     pip install -r requirements.txt
 
 

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -336,6 +336,12 @@ git-tree-sha1 = "7b1d07f411bc8ddb7977ec7f377b97b158514fe0"
 uuid = "189a3867-3050-52da-a836-e630ba90ab69"
 version = "0.2.0"
 
+[[Requires]]
+deps = ["UUIDs"]
+git-tree-sha1 = "cfbac6c1ed70c002ec6361e7fd334f02820d6419"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "1.1.2"
+
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -39,11 +39,6 @@ git-tree-sha1 = "c3598e525718abcc440f69cc6d5f60dda0a1b61e"
 uuid = "6e34b625-4abd-537c-b88f-471c36dfa7a0"
 version = "1.0.6+5"
 
-[[CEnum]]
-git-tree-sha1 = "215a9aa4a1f23fbd05b92769fdd62559488d70e9"
-uuid = "fa961155-64e5-5f13-b03f-caf6b980ea82"
-version = "0.4.1"
-
 [[CSV]]
 deps = ["CategoricalArrays", "DataFrames", "Dates", "Mmap", "Parsers", "PooledArrays", "SentinelArrays", "Tables", "Unicode"]
 git-tree-sha1 = "f095e44feec53d0ae809714a78c25908d1f370e6"
@@ -153,12 +148,6 @@ version = "0.10.14"
 [[Future]]
 deps = ["Random"]
 uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
-
-[[Gurobi]]
-deps = ["CEnum", "Libdl", "MathOptInterface"]
-git-tree-sha1 = "1719220ceddc23fafa82e9fcc28543a81505e5f3"
-uuid = "2e9cd046-0924-5485-92f1-d5272153d98b"
-version = "0.9.3"
 
 [[HDF5]]
 deps = ["Blosc", "HDF5_jll", "Libdl", "Mmap", "Random"]

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,6 @@ version = "0.1.0"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-Gurobi = "2e9cd046-0924-5485-92f1-d5272153d98b"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 MAT = "23992714-dd62-5051-b70f-ba57cb901cac"
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
@@ -16,5 +15,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 DataFrames = "0.21"
-Gurobi = "0.9"
 JuMP = "0.21.3"

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 MAT = "23992714-dd62-5051-b70f-ba57cb901cac"
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/pyreisejl/utility/call.py
+++ b/pyreisejl/utility/call.py
@@ -34,89 +34,109 @@ def _record_scenario(scenario_id, runtime):
     )
 
 
-def launch_scenario(
-    start_date, end_date, interval, input_dir, execute_dir=None, threads=None
-):
-    """Launches the scenario.
+class Launcher:
+    """Parent class for solver-specific scenario launchers.
 
     :param str start_date: start date of simulation as 'YYYY-MM-DD HH:MM:SS',
-    where HH, MM, and SS are optional.
+        where HH, MM, and SS are optional.
     :param str end_date: end date of simulation as 'YYYY-MM-DD HH:MM:SS',
-    where HH, MM, and SS are optional.
+        where HH, MM, and SS are optional.
     :param int interval: length of each interval in hours
     :param str input_dir: directory with input data
-    :param None/str execute_dir: directory for execute data. None defaults to an
-    execute folder that will be created in the input directory
-    :param None/int threads: number of threads to use, None defaults to auto.
-    :return: (*int*) runtime of scenario in seconds
     :raises InvalidDateArgument: if start_date is posterior to end_date
-    :raises InvalidInterval: if the interval does not evently divide the given date range
+    :raises InvalidInterval: if the interval doesn't evently divide the given date range
     """
-    # extract time limits from 'demand.csv'
-    with open(os.path.join(input_dir, "demand.csv")) as profile:
-        min_ts, max_ts, freq = extract_date_limits(profile)
 
-    dates = pd.date_range(start=min_ts, end=max_ts, freq=freq)
+    def __init__(self, start_date, end_date, interval, input_dir):
+        """Constructor."""
+        # extract time limits from 'demand.csv'
+        with open(os.path.join(input_dir, "demand.csv")) as profile:
+            min_ts, max_ts, freq = extract_date_limits(profile)
 
-    start_ts = validate_time_format(start_date)
-    end_ts = validate_time_format(end_date, end_date=True)
+        dates = pd.date_range(start=min_ts, end=max_ts, freq=freq)
 
-    # make sure the dates are within the time frame we have data for
-    validate_time_range(start_ts, min_ts, max_ts)
-    validate_time_range(end_ts, min_ts, max_ts)
+        start_ts = validate_time_format(start_date)
+        end_ts = validate_time_format(end_date, end_date=True)
 
-    if start_ts > end_ts:
-        raise InvalidDateArgument(
-            f"The start date ({start_ts}) cannot be after the end date ({end_ts})."
+        # make sure the dates are within the time frame we have data for
+        validate_time_range(start_ts, min_ts, max_ts)
+        validate_time_range(end_ts, min_ts, max_ts)
+
+        if start_ts > end_ts:
+            raise InvalidDateArgument(
+                f"The start date ({start_ts}) cannot be after the end date ({end_ts})."
+            )
+
+        # Julia starts at 1
+        start_index = dates.get_loc(start_ts) + 1
+        end_index = dates.get_loc(end_ts) + 1
+
+        # Calculate number of intervals
+        ts_range = end_index - start_index + 1
+        if ts_range % interval > 0:
+            raise InvalidInterval(
+                "This interval does not evenly divide the given date range."
+            )
+        self.start_index = start_index
+        self.interval = interval
+        self.n_interval = int(ts_range / interval)
+        self.input_dir = input_dir
+        print("Validation complete!")
+
+    def _print_settings(self):
+        print("Launching scenario with parameters:")
+        print(
+            {
+                "interval": self.interval,
+                "n_interval": self.n_interval,
+                "start_index": self.start_index,
+                "input_dir": self.input_dir,
+                "execute_dir": self.execute_dir,
+                "threads": self.threads,
+            }
         )
 
-    # Julia starts at 1
-    start_index = dates.get_loc(start_ts) + 1
-    end_index = dates.get_loc(end_ts) + 1
+    def launch_scenario(self):
+        # This should be defined in sub-classes
+        raise NotImplementedError
 
-    # Calculate number of intervals
-    ts_range = end_index - start_index + 1
-    if ts_range % interval > 0:
-        raise InvalidInterval(
-            "This interval does not evenly divide the given date range."
+
+class GurobiLauncher(Launcher):
+    def launch_scenario(self, execute_dir=None, threads=None, solver_kwargs=None):
+        """Launches the scenario.
+
+        :param None/str execute_dir: directory for execute data. None defaults to an
+            execute folder that will be created in the input directory
+        :param None/int threads: number of threads to use.
+        :param None/dict solver_kwargs: keyword arguments to pass to solver (if any).
+        :return: (*int*) runtime of scenario in seconds
+        """
+        self.execute_dir = execute_dir
+        self.threads = threads
+        self._print_settings()
+        # Import these within function because there is a lengthy compilation step
+        from julia.api import Julia
+
+        Julia(compiled_modules=False)
+        from julia import Gurobi  # noqa: F401
+        from julia import REISE
+
+        start = time()
+        REISE.run_scenario_gurobi(
+            interval=self.interval,
+            n_interval=self.n_interval,
+            start_index=self.start_index,
+            inputfolder=self.input_dir,
+            outputfolder=self.execute_dir,
+            threads=self.threads,
         )
+        end = time()
 
-    n_interval = int(ts_range / interval)
+        runtime = round(end - start)
+        hours, minutes, seconds = sec2hms(runtime)
+        print(f"Run time: {hours}:{minutes:02d}:{seconds:02d}")
 
-    # Import these within function because there is a lengthy compilation step
-    from julia.api import Julia
-
-    Julia(compiled_modules=False)
-    from julia import REISE
-
-    print("Validation complete! Launching scenario with parameters:")
-    print(
-        {
-            "interval": interval,
-            "n_interval": n_interval,
-            "start_index": start_index,
-            "input_dir": input_dir,
-            "execute_dir": execute_dir,
-            "threads": threads,
-        }
-    )
-
-    start = time()
-    REISE.run_scenario(
-        interval=interval,
-        n_interval=n_interval,
-        start_index=start_index,
-        inputfolder=input_dir,
-        outputfolder=execute_dir,
-        threads=threads,
-    )
-    end = time()
-
-    runtime = round(end - start)
-    hours, minutes, seconds = sec2hms(runtime)
-    print(f"Run time: {hours}:{minutes:02d}:{seconds:02d}")
-
-    return runtime
+        return runtime
 
 
 def main(args):
@@ -142,14 +162,13 @@ def main(args):
         )
         raise WrongNumberOfArguments(err_str)
 
-    runtime = launch_scenario(
+    launcher = GurobiLauncher(
         args.start_date,
         args.end_date,
         args.interval,
         args.input_dir,
-        args.execute_dir,
-        args.threads,
     )
+    runtime = launcher.launch_scenario(args.execute_dir, args.threads)
 
     # If using PowerSimData, record the runtime
     if args.scenario_id:

--- a/src/REISE.jl
+++ b/src/REISE.jl
@@ -5,6 +5,7 @@ import DataFrames
 import Dates
 import JuMP
 import MAT
+import Requires
 import SparseArrays: sparse, SparseMatrixCSC
 
 
@@ -16,6 +17,13 @@ include("model.jl")         # Defines _build_model (used in interval_loop)
 include("loop.jl")          # Defines interval_loop
 include("query.jl")         # Defines get_results (used in interval_loop)
 include("save.jl")          # Defines save_input_mat, save_results
+
+
+function __init__()
+    Requires.@require Gurobi="2e9cd046-0924-5485-92f1-d5272153d98b" begin
+        include(joinpath("solver_specific", "gurobi.jl"))
+    end
+end
 
 
 """
@@ -39,9 +47,12 @@ Run a scenario consisting of several intervals.
 function run_scenario(;
         num_segments::Int=1, interval::Int, n_interval::Int, start_index::Int,
         inputfolder::String, outputfolder::Union{String, Nothing}=nothing,
-        threads::Union{Int, Nothing}=nothing, optimizer_factory=nothing)
+        threads::Union{Int, Nothing}=nothing, optimizer_factory=nothing,
+        solver_kwargs::Union{Dict, Nothing}=nothing)
     isnothing(optimizer_factory) && error("optimizer_factory must be specified")
     # Setup things that build once
+    # If no solver kwargs passed, instantiate an empty dict
+    solver_kwargs = something(solver_kwargs, Dict())
     # If outputfolder not given, by default assign it inside inputfolder
     isnothing(outputfolder) && (outputfolder = joinpath(inputfolder, "output"))
     # If outputfolder doesn't exist (isdir evaluates false) create it (mkdir)

--- a/src/solver_specific/gurobi.jl
+++ b/src/solver_specific/gurobi.jl
@@ -1,0 +1,23 @@
+# Importing Gurobi in this way avoids a warning with Requires
+import .Gurobi
+
+
+function run_scenario_gurobi(; solver_kwargs::Union{Dict, Nothing}=nothing, kwargs...)
+    solver_kwargs = something(solver_kwargs, Dict("Method" => 2, "Crossover" => 0))
+    try
+        global env = Gurobi.Env()
+        global m = run_scenario(;
+            optimizer_factory=env, solver_kwargs=solver_kwargs, kwargs...)
+    finally
+        Gurobi.finalize(JuMP.backend(m))
+        Gurobi.finalize(env)
+        println("Connection closed successfully!")
+    end
+    # Return `nothing` to prevent `m` from the `try` block from being returned
+    return nothing
+end
+
+
+function new_model(env::Gurobi.Env)
+    return JuMP.direct_model(Gurobi.Optimizer(env))
+end


### PR DESCRIPTION
### Purpose

Removes the requirement that Gurobi.jl be installed as a requirement of REISE.jl, since it can now be run with any optimizer (Closes #101). Allows the user to pass solver settings from python (Closes #102).

### What is the code doing

- In **src/solver_specific/gurobi.jl**: we move all code that depends on importing Gurobi (from **REISE.jl** and **loop.jl**)
  - `run_scenario_gurobi` wraps around `run_scenario` as defined in **src/REISE.jl**.
  - The new function definition with the call signature `new_model(env::Gurobi.Env)` creates another method for the `new_model` function defined in **loop.jl**; the one in **loop.jl** will take any type, but if we pass a `Gurobi.Env` object then Julia will use the most specific method available, the one defined in **gurobi.jl** (see https://docs.julialang.org/en/v1/manual/methods/ for more details).
- In **src/REISE.jl**:
  - We remove the `Gurobi` import, instead importing `Requires`, and using this package to only include **src/solver_specific/gurobi.jl** if Gurobi is also imported.
  - We allow a dictionary `solver_kwargs` to be passed to `run_scenario`.
  - We return the `JuMP.Model` instead that we built in `interval_loop` so that when we are running with the shared gurobi environment in we can free the Gurobi environment in the most proper way according to their documentation.
- In **src/loop.jl**, in `interval_loop`:
  - We refactor how we check which solver is being used to a more general form.
  - We return the `JuMP.Model` instance, to get returned via `run_scenario` and cleaned up as necessary in `run_scenario_gurobi`
- In **pyreisejl/utility/call.py**:
  - We refactor the `launch_scenario` function into a class with methods, and we define a gurobi-specific subclass that does gurobi-specific things.
  - We refactor `main` to use this new object-based launch method.

### Testing

#### Julia

From Julia, we can verify that this works by creating fresh environments, installing REISE.jl along with with different solvers (note that Gurobi.jl is not installed by default), and running as desired:

##### With Gurobi.jl

```julia
julia> import Pkg

julia> Pkg.activate("Gurobitest")
 Activating new environment at `C:\Users\DanielOlsen\repos\bes\Gurobitest\Project.toml`

julia> Pkg.develop(path=raw"C:\Users\DanielOlsen\repos\bes\REISE.jl")
Path `C:\Users\DanielOlsen\repos\bes\REISE.jl` exists and looks like the correct package. Using existing path.
  Resolving package versions...
Updating `C:\Users\DanielOlsen\repos\bes\Gurobitest\Project.toml`
  [b654829c] + REISE v0.1.0 `C:\Users\DanielOlsen\repos\bes\REISE.jl`
Updating `C:\Users\DanielOlsen\repos\bes\Gurobitest\Manifest.toml`
  [56f22d72] + Artifacts v1.3.0
  [6e4b80f9] + BenchmarkTools v0.5.0
  [a74b3585] + Blosc v0.7.0
  [0b7ba130] + Blosc_jll v1.14.3+1
  [e1450e63] + BufferedStreams v1.0.0
  [6e34b625] + Bzip2_jll v1.0.6+5
  [336ed68f] + CSV v0.8.3
  [49dc2e85] + Calculus v0.5.1
  [324d7699] + CategoricalArrays v0.8.3
  [d360d2e6] + ChainRulesCore v0.9.27
  [523fee87] + CodecBzip2 v0.7.2
  [944b1d66] + CodecZlib v0.7.0
  [bbf7d656] + CommonSubexpressions v0.3.0
  [34da2185] + Compat v3.25.0
  [e66e0078] + CompilerSupportLibraries_jll v0.3.4+0
  [8f4d0f93] + Conda v1.5.0
  [9a962f9c] + DataAPI v1.5.0
  [a93c6f00] + DataFrames v0.21.8
  [864edb3b] + DataStructures v0.18.9
  [e2d170a0] + DataValueInterfaces v1.0.0
  [163ba53b] + DiffResults v1.0.3
  [b552c78f] + DiffRules v1.0.2
  [f6369f11] + ForwardDiff v0.10.15
  [f67ccb44] + HDF5 v0.15.2
  [0234f1f7] + HDF5_jll v1.12.0+1
  [cd3eb016] + HTTP v0.9.2
  [83e8ac13] + IniFile v0.5.0
  [41ab1584] + InvertedIndices v1.0.0
  [82899510] + IteratorInterfaceExtensions v1.0.0
  [692b3bcd] + JLLWrappers v1.2.0
  [682c06a0] + JSON v0.21.1
  [7d188eb4] + JSONSchema v0.3.3
  [4076af6c] + JuMP v0.21.6
  [deac9b47] + LibCURL_jll v7.70.0+2
  [29816b5a] + LibSSH2_jll v1.9.0+3
  [5ced341a] + Lz4_jll v1.9.2+2
  [23992714] + MAT v0.10.1
  [1914dd2f] + MacroTools v0.5.6
  [b8f27783] + MathOptInterface v0.9.19
  [739be429] + MbedTLS v1.0.3
  [c8ffd9c3] + MbedTLS_jll v2.16.8+1
  [e1d29d7a] + Missings v0.4.5
  [d8a4904e] + MutableArithmetics v0.2.14
  [77ba4419] + NaNMath v0.3.5
  [458c3c95] + OpenSSL_jll v1.1.1+6
  [efe28fd5] + OpenSpecFun_jll v0.5.3+4
  [bac558e1] + OrderedCollections v1.3.3
  [69de0a69] + Parsers v1.0.15
  [2dfb63ee] + PooledArrays v0.5.3
  [438e738f] + PyCall v1.92.2
  [b654829c] + REISE v0.1.0 `C:\Users\DanielOlsen\repos\bes\REISE.jl`
  [189a3867] + Reexport v0.2.0
  [ae029012] + Requires v1.1.2
  [91c51154] + SentinelArrays v1.2.16
  [a2af1166] + SortingAlgorithms v0.3.1
  [276daf66] + SpecialFunctions v1.2.1
  [90137ffa] + StaticArrays v1.0.1
  [856f2bd8] + StructTypes v1.2.3
  [3783bdb8] + TableTraits v1.0.0
  [bd369af6] + Tables v1.3.1
  [3bb67fe8] + TranscodingStreams v0.9.5
  [5c2747f8] + URIs v1.2.0
  [81def892] + VersionParsing v1.2.0
  [a5390f91] + ZipFile v0.9.3
  [83775a58] + Zlib_jll v1.2.11+18
  [3161d3a3] + Zstd_jll v1.4.8+0
  [8e850ede] + nghttp2_jll v1.40.0+2
  [2a0f44e3] + Base64
  [ade2ca70] + Dates
  [8bb1440f] + DelimitedFiles
  [8ba89e20] + Distributed
  [9fa8497b] + Future
  [b77e0a4c] + InteractiveUtils
  [76f85450] + LibGit2
  [8f399da3] + Libdl
  [37e2e46d] + LinearAlgebra
  [56ddb016] + Logging
  [d6f4376e] + Markdown
  [a63ad114] + Mmap
  [44cfe95a] + Pkg
  [de0858da] + Printf
  [3fa0cd96] + REPL
  [9a3f8284] + Random
  [ea8e919c] + SHA
  [9e88b42a] + Serialization
  [1a1011a3] + SharedArrays
  [6462fe0b] + Sockets
  [2f01184e] + SparseArrays
  [10745b16] + Statistics
  [8dfed614] + Test
  [cf7118a7] + UUIDs
  [4ec0a83e] + Unicode

julia> Pkg.add("Gurobi")
   Updating registry at `C:\Users\DanielOlsen\.julia\registries\General`
   Updating git-repo `https://github.com/JuliaRegistries/General.git`
  Resolving package versions...
Updating `C:\Users\DanielOlsen\repos\bes\Gurobitest\Project.toml`
  [2e9cd046] + Gurobi v0.9.7
Updating `C:\Users\DanielOlsen\repos\bes\Gurobitest\Manifest.toml`
  [fa961155] + CEnum v0.4.1
  [2e9cd046] + Gurobi v0.9.7

julia> import Gurobi

julia> import REISE

julia> REISE.run_scenario_gurobi(; interval=24, n_interval=1, start_index=1, inputfolder=raw"C:\Users\DanielOlsen\repos\bes\scenario_2066", outputfolder=raw"C:\Users\DanielOlsen\repos\bes\scenario_2066\output4")
Compute Server job ID: 2c0b1485-0665-427d-9028-c4958d18392b
Capacity available on 'https://ip-10-0-67-145:61000' - connecting...
Established HTTPS encrypted connection
Reading from folder: C:\Users\DanielOlsen\repos\bes\scenario_2066
...loading case.mat
...loading demand.csv
...loading hydro.csv
...loading wind.csv
...loading solar.csv
File case_storage.mat not found in C:\Users\DanielOlsen\repos\bes\scenario_2066
All scenario files loaded!
linearizing
All preparation complete!
Redirecting outputs, see stdout.log & stderr.err in outputfolder

Compute Server communication statistics:
  Sent: 24.958 MBytes in 32 msgs and 11.01s (2.27 MB/s)
  Received: 7.274 MBytes in 54 msgs and 10.95s (0.66 MB/s)

Connection closed successfully!

julia>
```

##### With GLPK

```julia
julia> import Pkg

julia> Pkg.activate("GLPKtest")
 Activating new environment at `C:\Users\DanielOlsen\repos\bes\GLPKtest\Project.toml`

julia> Pkg.develop(path=raw"C:\Users\DanielOlsen\repos\bes\REISE.jl")
Path `C:\Users\DanielOlsen\repos\bes\REISE.jl` exists and looks like the correct package. Using existing path.
  Resolving package versions...
Updating `C:\Users\DanielOlsen\repos\bes\GLPKtest\Project.toml`
  [b654829c] + REISE v0.1.0 `C:\Users\DanielOlsen\repos\bes\REISE.jl`
Updating `C:\Users\DanielOlsen\repos\bes\GLPKtest\Manifest.toml`
  [56f22d72] + Artifacts v1.3.0
  [6e4b80f9] + BenchmarkTools v0.5.0
  [a74b3585] + Blosc v0.7.0
  [0b7ba130] + Blosc_jll v1.14.3+1
  [e1450e63] + BufferedStreams v1.0.0
  [6e34b625] + Bzip2_jll v1.0.6+5
  [336ed68f] + CSV v0.8.3
  [49dc2e85] + Calculus v0.5.1
  [324d7699] + CategoricalArrays v0.8.3
  [d360d2e6] + ChainRulesCore v0.9.27
  [523fee87] + CodecBzip2 v0.7.2
  [944b1d66] + CodecZlib v0.7.0
  [bbf7d656] + CommonSubexpressions v0.3.0
  [34da2185] + Compat v3.25.0
  [e66e0078] + CompilerSupportLibraries_jll v0.3.4+0
  [8f4d0f93] + Conda v1.5.0
  [9a962f9c] + DataAPI v1.5.0
  [a93c6f00] + DataFrames v0.21.8
  [864edb3b] + DataStructures v0.18.9
  [e2d170a0] + DataValueInterfaces v1.0.0
  [163ba53b] + DiffResults v1.0.3
  [b552c78f] + DiffRules v1.0.2
  [f6369f11] + ForwardDiff v0.10.15
  [f67ccb44] + HDF5 v0.15.2
  [0234f1f7] + HDF5_jll v1.12.0+1
  [cd3eb016] + HTTP v0.9.2
  [83e8ac13] + IniFile v0.5.0
  [41ab1584] + InvertedIndices v1.0.0
  [82899510] + IteratorInterfaceExtensions v1.0.0
  [692b3bcd] + JLLWrappers v1.2.0
  [682c06a0] + JSON v0.21.1
  [7d188eb4] + JSONSchema v0.3.3
  [4076af6c] + JuMP v0.21.6
  [deac9b47] + LibCURL_jll v7.70.0+2
  [29816b5a] + LibSSH2_jll v1.9.0+3
  [5ced341a] + Lz4_jll v1.9.2+2
  [23992714] + MAT v0.10.1
  [1914dd2f] + MacroTools v0.5.6
  [b8f27783] + MathOptInterface v0.9.19
  [739be429] + MbedTLS v1.0.3
  [c8ffd9c3] + MbedTLS_jll v2.16.8+1
  [e1d29d7a] + Missings v0.4.5
  [d8a4904e] + MutableArithmetics v0.2.14
  [77ba4419] + NaNMath v0.3.5
  [458c3c95] + OpenSSL_jll v1.1.1+6
  [efe28fd5] + OpenSpecFun_jll v0.5.3+4
  [bac558e1] + OrderedCollections v1.3.3
  [69de0a69] + Parsers v1.0.15
  [2dfb63ee] + PooledArrays v0.5.3
  [438e738f] + PyCall v1.92.2
  [b654829c] + REISE v0.1.0 `C:\Users\DanielOlsen\repos\bes\REISE.jl`
  [189a3867] + Reexport v0.2.0
  [ae029012] + Requires v1.1.2
  [91c51154] + SentinelArrays v1.2.16
  [a2af1166] + SortingAlgorithms v0.3.1
  [276daf66] + SpecialFunctions v1.2.1
  [90137ffa] + StaticArrays v1.0.1
  [856f2bd8] + StructTypes v1.2.3
  [3783bdb8] + TableTraits v1.0.0
  [bd369af6] + Tables v1.3.1
  [3bb67fe8] + TranscodingStreams v0.9.5
  [5c2747f8] + URIs v1.2.0
  [81def892] + VersionParsing v1.2.0
  [a5390f91] + ZipFile v0.9.3
  [83775a58] + Zlib_jll v1.2.11+18
  [3161d3a3] + Zstd_jll v1.4.8+0
  [8e850ede] + nghttp2_jll v1.40.0+2
  [2a0f44e3] + Base64
  [ade2ca70] + Dates
  [8bb1440f] + DelimitedFiles
  [8ba89e20] + Distributed
  [9fa8497b] + Future
  [b77e0a4c] + InteractiveUtils
  [76f85450] + LibGit2
  [8f399da3] + Libdl
  [37e2e46d] + LinearAlgebra
  [56ddb016] + Logging
  [d6f4376e] + Markdown
  [a63ad114] + Mmap
  [44cfe95a] + Pkg
  [de0858da] + Printf
  [3fa0cd96] + REPL
  [9a3f8284] + Random
  [ea8e919c] + SHA
  [9e88b42a] + Serialization
  [1a1011a3] + SharedArrays
  [6462fe0b] + Sockets
  [2f01184e] + SparseArrays
  [10745b16] + Statistics
  [8dfed614] + Test
  [cf7118a7] + UUIDs
  [4ec0a83e] + Unicode

julia> Pkg.add("GLPK")
   Updating registry at `C:\Users\DanielOlsen\.julia\registries\General`
   Updating git-repo `https://github.com/JuliaRegistries/General.git`
  Resolving package versions...
Updating `C:\Users\DanielOlsen\repos\bes\GLPKtest\Project.toml`
  [60bf3e95] + GLPK v0.14.6
Updating `C:\Users\DanielOlsen\repos\bes\GLPKtest\Manifest.toml`
  [b99e7846] + BinaryProvider v0.5.10
  [fa961155] + CEnum v0.4.1
  [60bf3e95] + GLPK v0.14.6
  [e8aa6df9] + GLPK_jll v4.64.0+0
  [781609d7] + GMP_jll v6.1.2+6

julia> import REISE

julia> import GLPK

julia> REISE.run_scenario(; interval=1, n_interval=3, start_index=1, inputfolder=raw"C:\Users\DanielOlsen\repos\bes\scenario_2066", outputfolder=raw"C:\Users\DanielOlsen\repos\bes\scenario_2066\output2", optimizer_factory=GLPK.Optimizer)
Reading from folder: C:\Users\DanielOlsen\repos\bes\scenario_2066
...loading case.mat
...loading demand.csv
...loading hydro.csv
...loading wind.csv
...loading solar.csv
File case_storage.mat not found in C:\Users\DanielOlsen\repos\bes\scenario_2066
All scenario files loaded!
linearizing
All preparation complete!
Redirecting outputs, see stdout.log & stderr.err in outputfolder

julia>
```

#### Python

```
> python call.py -s 2016-01-01 -e 2016-01-03 -int 24 -i C:\Users\DanielOlsen\repos\bes\scenario_2066 -o C:\Users\DanielOlsen\repos\bes\scenario_2066\output3
Validation complete!
Launching scenario with parameters:
{'interval': 24, 'n_interval': 3, 'start_index': 1, 'input_dir': 'C:\\Users\\DanielOlsen\\repos\\bes\\scenario_2066', 'execute_dir': None, 'threads': None}
Waiting for cloud server to start (pool default)...
Starting...
Starting...
Starting...
Starting...
Compute Server job ID: e745ace6-8416-474e-ad79-94da0cc1488b
Capacity available on 'https://ip-10-0-68-159:61000' - connecting...
Established HTTPS encrypted connection
Reading from folder: C:\Users\DanielOlsen\repos\bes\scenario_2066
...loading case.mat
...loading demand.csv
...loading hydro.csv
...loading wind.csv
...loading solar.csv
File case_storage.mat not found in C:\Users\DanielOlsen\repos\bes\scenario_2066
All scenario files loaded!
linearizing
All preparation complete!
Redirecting outputs, see stdout.log & stderr.err in outputfolder
Connection closed successfully!
Run time: 0:02:57

Compute Server communication statistics:
  Sent: 50.894 MBytes in 65 msgs and 17.45s (2.92 MB/s)
  Received: 21.755 MBytes in 150 msgs and 28.71s (0.76 MB/s)
```

### Time to review

30-60 minutes.