### PR TITLE
ci: use black profile for isort

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,10 +12,13 @@ changedir = pyreisejl
 commands =
     pytest: pytest 
     format: black .
-    format: isort -m 3 --tc .
+    format: isort .
     checkformatting: black . --check --diff
-    checkformatting: isort -m 3 --tc --check --diff .
+    checkformatting: isort --check --diff .
     flake8: flake8
 
 [flake8]
 ignore = E501,E731
+
+[isort]
+profile = black


### PR DESCRIPTION
### Purpose
We can take advantage of isort's built in "profile" for black compatibility. This includes a line length option which we were msising, along with a couple others I'm not sure about. [Source](https://github.com/PyCQA/isort/blob/develop/isort/profiles.py) from their repo is easy to read.

### What the code is doing
Added isort section in tox.ini

### Testing
Ran `tox -e format` locally, and ci passes.

### Time estimate
5 min