### PR TITLE
fix: add parentheses for proper boolean algebra

### DIFF
--- a/src/loop.jl
+++ b/src/loop.jl
@@ -135,7 +135,7 @@ function interval_loop(factory_like, model_kwargs::Dict,
                 results = get_results(f, voi, model_kwargs["case"])
                 break
             elseif ((status in numeric_statuses)
-                    & JuMP.solver_name(m) == "Gurobi"
+                    & (JuMP.solver_name(m) == "Gurobi")
                     & !("BarHomogeneous" in keys(solver_kwargs)))
                 # if Gurobi, and BarHomogeneous is not enabled, enable it and re-solve
                 solver_kwargs["BarHomogeneous"] = 1
@@ -150,7 +150,7 @@ function interval_loop(factory_like, model_kwargs::Dict,
                 JuMP.set_optimizer_attributes(m, pairs(solver_kwargs)...)
                 m, voi = _build_model(m; symbolize(model_kwargs)...)
                 intervals_without_loadshed = 0
-            elseif (JuMP.solver_name(m) == "Gurobi"
+            elseif ((JuMP.solver_name(m) == "Gurobi")
                     & !("BarHomogeneous" in keys(solver_kwargs)))
                 # if Gurobi, and BarHomogeneous is not enabled, enable it and re-solve
                 solver_kwargs["BarHomogeneous"] = 1


### PR DESCRIPTION
### Purpose

Fix a bug introduced in https://github.com/Breakthrough-Energy/REISE.jl/pull/106.

### Details

Several scenarios have failed on the server. I managed to get a traceback (requires running from julia manually on the server, since these Exceptions don't make it into the recorded stdout/stderr in our current setup) and what I got is:
```julia
ERROR: MethodError: no method matching &(::Bool, ::String)
Closest candidates are:
  &(::Any, ::Any, ::Any, ::Any...) at operators.jl:538
  &(::Bool, ::Missing) at missing.jl:160
  &(::Bool, ::Bool) at bool.jl:40
  ...
Stacktrace:
 [1] interval_loop(::Gurobi.Env, ::Dict{String,Any}, ::Dict{String,Int64}, ::Int64, ::Int64, ::Int64, ::String, ::String, ::Int64) at /home/bes/pcm/REISE.jl/src/loop.jl:138
 [2] (::REISE.var"#95#96"{Int64,String,Gurobi.Env,Int64,Dict{String,Any}})() at /home/bes/pcm/REISE.jl/src/REISE.jl:85
 [3] #83 at /home/bes/pcm/REISE.jl/src/save.jl:113 [inlined]
 [4] redirect_stderr(::REISE.var"#83#87"{REISE.var"#95#96"{Int64,String,Gurobi.Env,Int64,Dict{String,Any}}}, ::IOStream) at ./stream.jl:1150
 [5] #82 at /home/bes/pcm/REISE.jl/src/save.jl:112 [inlined]
 [6] redirect_stdout(::REISE.var"#82#86"{IOStream,REISE.var"#95#96"{Int64,String,Gurobi.Env,Int64,Dict{String,Any}}}, ::IOStream) at ./stream.jl:1150
 [7] #81 at /home/bes/pcm/REISE.jl/src/save.jl:111 [inlined]
 [8] open(::REISE.var"#81#85"{IOStream,REISE.var"#95#96"{Int64,String,Gurobi.Env,Int64,Dict{String,Any}}}, ::String, ::Vararg{String,N} where N; kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at ./io.jl:325
 [9] open at ./io.jl:323 [inlined]
 [10] #80 at /home/bes/pcm/REISE.jl/src/save.jl:110 [inlined]
 [11] open(::REISE.var"#80#84"{REISE.var"#95#96"{Int64,String,Gurobi.Env,Int64,Dict{String,Any}},String}, ::String, ::Vararg{String,N} where N; kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at ./io.jl:325
 [12] open at ./io.jl:323 [inlined]
 [13] redirect_stdout_stderr(::REISE.var"#95#96"{Int64,String,Gurobi.Env,Int64,Dict{String,Any}}, ::String, ::String) at /home/bes/pcm/REISE.jl/src/save.jl:109
 [14] run_scenario(; num_segments::Int64, interval::Int64, n_interval::Int64, start_index::Int64, inputfolder::String, outputfolder::Nothing, threads::Int64, optimizer_factory::Gurobi.Env, solver_kwargs::Dict{String,Int64}, resume_at::Int64) at /home/bes/pcm/REISE.jl/src/REISE.jl:83
 [15] run_scenario_gurobi(; solver_kwargs::Nothing, kwargs::Base.Iterators.Pairs{Symbol,Any,NTuple{5,Symbol},NamedTuple{(:interval, :n_interval, :start_index, :inputfolder, :threads),Tuple{Int64,Int64,Int64,String,Int64}}}) at /home/bes/pcm/REISE.jl/src/solver_specific/gurobi.jl:9
 [16] top-level scope at REPL[3]:1
```

From looking at what is recorded in stdout, we see that the last interval encountered a non-optimal result (I've seen both Numeric and Suboptimal), and that neither load shedding nor the `BarHomogeneous` setting of Gurobi were enabled, so based on the logic in `interval_loop` we should be modifying the problem and re-running if not for this Exception.

Looking at the [Julia Operator Precedence](https://docs.julialang.org/en/v1/manual/mathematical-operations/#Operator-Precedence-and-Associativity), this error makes sense, since `&` has precedence over `==`, but there's no built-in way to `&` a `Bool` and a `String`.

### What is the code doing

Adding parentheses, so that the equality is evaluated to a `Bool` before any other binary logic operations.

### Testing

Approximately 40 scenarios failed with the old code, re-running the new code they all completed successfully.

### Time to review

5 minutes.