### PR TITLE
feat: add more command line inputs

### DIFF
--- a/pyreisejl/utility/call.py
+++ b/pyreisejl/utility/call.py
@@ -58,6 +58,7 @@ def main(args):
         execute_dir=args.execute_dir,
         threads=args.threads,
         julia_env=args.julia_env,
+        num_segments=args.linearization_segments,
     )
     runtime = launcher.launch_scenario()
 

--- a/pyreisejl/utility/call.py
+++ b/pyreisejl/utility/call.py
@@ -55,8 +55,10 @@ def main(args):
         args.end_date,
         args.interval,
         args.input_dir,
+        args.execute_dir,
+        args.threads,
     )
-    runtime = launcher.launch_scenario(args.execute_dir, args.threads)
+    runtime = launcher.launch_scenario()
 
     # If using PowerSimData, record the runtime
     if args.scenario_id:

--- a/pyreisejl/utility/call.py
+++ b/pyreisejl/utility/call.py
@@ -55,8 +55,9 @@ def main(args):
         args.end_date,
         args.interval,
         args.input_dir,
-        args.execute_dir,
-        args.threads,
+        execute_dir=args.execute_dir,
+        threads=args.threads,
+        julia_env=args.julia_env,
     )
     runtime = launcher.launch_scenario()
 

--- a/pyreisejl/utility/launchers.py
+++ b/pyreisejl/utility/launchers.py
@@ -102,6 +102,12 @@ class Launcher:
         Julia(compiled_modules=False)
         return tuple([importlib.import_module(f"julia.{i}") for i in imports])
 
+    def parse_runtime(self, start, end):
+        runtime = round(end - start)
+        hours, minutes, seconds = sec2hms(runtime)
+        print(f"Run time: {hours}:{minutes:02d}:{seconds:02d}")
+        return runtime
+
     def launch_scenario(self):
         # This should be defined in sub-classes
         raise NotImplementedError
@@ -130,11 +136,7 @@ class GLPKLauncher(Launcher):
         )
         end = time()
 
-        runtime = round(end - start)
-        hours, minutes, seconds = sec2hms(runtime)
-        print(f"Run time: {hours}:{minutes:02d}:{seconds:02d}")
-
-        return runtime
+        return self.parse_runtime(start, end)
 
 
 class GurobiLauncher(Launcher):
@@ -160,11 +162,7 @@ class GurobiLauncher(Launcher):
         )
         end = time()
 
-        runtime = round(end - start)
-        hours, minutes, seconds = sec2hms(runtime)
-        print(f"Run time: {hours}:{minutes:02d}:{seconds:02d}")
-
-        return runtime
+        return self.parse_runtime(start, end)
 
 
 _launch_map = {"gurobi": GurobiLauncher, "glpk": GLPKLauncher}

--- a/pyreisejl/utility/launchers.py
+++ b/pyreisejl/utility/launchers.py
@@ -22,11 +22,24 @@ class Launcher:
         where HH, MM, and SS are optional.
     :param int interval: length of each interval in hours
     :param str input_dir: directory with input data
+    :param None/str execute_dir: directory for execute data. None defaults to an
+        execute folder that will be created in the input directory
+    :param None/int threads: number of threads to use.
+    :param None/dict solver_kwargs: keyword arguments to pass to solver (if any).
     :raises InvalidDateArgument: if start_date is posterior to end_date
     :raises InvalidInterval: if the interval doesn't evently divide the given date range
     """
 
-    def __init__(self, start_date, end_date, interval, input_dir):
+    def __init__(
+        self,
+        start_date,
+        end_date,
+        interval,
+        input_dir,
+        execute_dir=None,
+        threads=None,
+        solver_kwargs=None,
+    ):
         """Constructor."""
         # extract time limits from 'demand.csv'
         with open(os.path.join(input_dir, "demand.csv")) as profile:
@@ -61,6 +74,10 @@ class Launcher:
         self.n_interval = int(ts_range / interval)
         self.input_dir = input_dir
         print("Validation complete!")
+        # These parameters are not validated
+        self.execute_dir = execute_dir
+        self.threads = threads
+        self.solver_kwargs = solver_kwargs
 
     def _print_settings(self):
         print("Launching scenario with parameters:")
@@ -81,17 +98,12 @@ class Launcher:
 
 
 class GLPKLauncher(Launcher):
-    def launch_scenario(self, execute_dir=None, threads=None, solver_kwargs=None):
+    def launch_scenario(self):
         """Launches the scenario.
 
-        :param None/str execute_dir: directory for execute data. None defaults to an
-            execute folder that will be created in the input directory
-        :param None/int threads: number of threads to use.
-        :param None/dict solver_kwargs: keyword arguments to pass to solver (if any).
         :return: (*int*) runtime of scenario in seconds
         """
-        self.execute_dir = execute_dir
-        self.threads = threads
+
         self._print_settings()
         print("INFO: threads not supported by GLPK, ignoring")
 
@@ -120,17 +132,11 @@ class GLPKLauncher(Launcher):
 
 
 class GurobiLauncher(Launcher):
-    def launch_scenario(self, execute_dir=None, threads=None, solver_kwargs=None):
+    def launch_scenario(self):
         """Launches the scenario.
 
-        :param None/str execute_dir: directory for execute data. None defaults to an
-            execute folder that will be created in the input directory
-        :param None/int threads: number of threads to use.
-        :param None/dict solver_kwargs: keyword arguments to pass to solver (if any).
         :return: (*int*) runtime of scenario in seconds
         """
-        self.execute_dir = execute_dir
-        self.threads = threads
         self._print_settings()
         # Import these within function because there is a lengthy compilation step
         from julia.api import Julia

--- a/pyreisejl/utility/launchers.py
+++ b/pyreisejl/utility/launchers.py
@@ -29,6 +29,7 @@ class Launcher:
     :param None/int threads: number of threads to use.
     :param None/dict solver_kwargs: keyword arguments to pass to solver (if any).
     :param str julia_env: path to the julia environment to be used to run simulation.
+    :param int num_segments: number of segments used for cost curve linearization.
     :raises InvalidDateArgument: if start_date is posterior to end_date
     :raises InvalidInterval: if the interval doesn't evently divide the given date range
     """
@@ -43,6 +44,7 @@ class Launcher:
         threads=None,
         solver_kwargs=None,
         julia_env=None,
+        num_segments=1,
     ):
         """Constructor."""
         # extract time limits from 'demand.csv'
@@ -83,11 +85,13 @@ class Launcher:
         self.threads = threads
         self.solver_kwargs = solver_kwargs
         self.julia_env = julia_env
+        self.num_segments = num_segments
 
     def _print_settings(self):
         print("Launching scenario with parameters:")
         print(
             {
+                "num_segments": self.num_segments,
                 "interval": self.interval,
                 "n_interval": self.n_interval,
                 "start_index": self.start_index,
@@ -144,6 +148,7 @@ class GLPKLauncher(Launcher):
             outputfolder=self.execute_dir,
             optimizer_factory=GLPK.Optimizer,
             solver_kwargs=self.solver_kwargs,
+            num_segments=self.num_segments,
         )
         end = time()
 
@@ -170,6 +175,7 @@ class GurobiLauncher(Launcher):
             outputfolder=self.execute_dir,
             threads=self.threads,
             solver_kwargs=self.solver_kwargs,
+            num_segments=self.num_segments,
         )
         end = time()
 

--- a/pyreisejl/utility/launchers.py
+++ b/pyreisejl/utility/launchers.py
@@ -194,4 +194,4 @@ def get_launcher(solver):
         return GurobiLauncher
     if solver.lower() not in _launch_map.keys():
         raise ValueError("Invalid solver")
-    return _launch_map[solver]
+    return _launch_map[solver.lower()]

--- a/pyreisejl/utility/launchers.py
+++ b/pyreisejl/utility/launchers.py
@@ -24,10 +24,11 @@ class Launcher:
         where HH, MM, and SS are optional.
     :param int interval: length of each interval in hours
     :param str input_dir: directory with input data
-    :param None/str execute_dir: directory for execute data. None defaults to an
-        execute folder that will be created in the input directory
-    :param None/int threads: number of threads to use.
-    :param None/dict solver_kwargs: keyword arguments to pass to solver (if any).
+    :param str execute_dir: directory for execute data. None defaults to an execute
+        folder that will be created in the input directory
+    :param int threads: number of threads to use. None defaults to letting the solver
+        decide.
+    :param dict solver_kwargs: keyword arguments to pass to solver (if any).
     :param str julia_env: path to the julia environment to be used to run simulation.
     :param int num_segments: number of segments used for cost curve linearization.
     :raises InvalidDateArgument: if start_date is posterior to end_date

--- a/pyreisejl/utility/launchers.py
+++ b/pyreisejl/utility/launchers.py
@@ -90,6 +90,7 @@ class Launcher:
                 "input_dir": self.input_dir,
                 "execute_dir": self.execute_dir,
                 "threads": self.threads,
+                "solver_kwargs": self.solver_kwargs,
             }
         )
 
@@ -125,6 +126,7 @@ class GLPKLauncher(Launcher):
             inputfolder=self.input_dir,
             outputfolder=self.execute_dir,
             optimizer_factory=GLPK.Optimizer,
+            solver_kwargs=self.solver_kwargs,
         )
         end = time()
 
@@ -154,6 +156,7 @@ class GurobiLauncher(Launcher):
             inputfolder=self.input_dir,
             outputfolder=self.execute_dir,
             threads=self.threads,
+            solver_kwargs=self.solver_kwargs,
         )
         end = time()
 

--- a/pyreisejl/utility/parser.py
+++ b/pyreisejl/utility/parser.py
@@ -88,6 +88,14 @@ def parse_call_args():
         help="The path to the julia environment within which to run REISE.jl. "
         "This is optional and defaults to the default julia environment.",
     )
+    parser.add_argument(
+        "-l",
+        "--linearization-segments",
+        type=int,
+        default=1,
+        help="The number of piecewise linear segments used to linearize cost curves. "
+        "This is optional and defaults to one.",
+    )
 
     # For backwards compatability with PowerSimData
     parser.add_argument(

--- a/pyreisejl/utility/parser.py
+++ b/pyreisejl/utility/parser.py
@@ -82,6 +82,12 @@ def parse_call_args():
         help="Specify the solver to run the optimization. Will default to gurobi. "
         f"Current solvers available are {solvers}.",
     )
+    parser.add_argument(
+        "-j",
+        "--julia-env",
+        help="The path to the julia environment within which to run REISE.jl. "
+        "This is optional and defaults to the default julia environment.",
+    )
 
     # For backwards compatability with PowerSimData
     parser.add_argument(


### PR DESCRIPTION
### Purpose

- Adds command-line specification of the number of linearization segments to use (Closes #98).
- Adds command-line specification of the julia environment to use (Closes #104)
- Actually use the solver keyword arguments (added in #106 as a parameter but not actually used at all)
- Properly interpret solvers that are specified from the command-line, regardless of upper or lower case (cleanup from #112)
- Refactor how Launcher objects are used to minimize redundant code.

### What is the code doing

- In **parser.py**: adding two new command-line arguments.
- In **call.py**: passing command-line arguments (including new ones) directly to the Launcher init.
- In **launchers.py**:
  - All parameters passed for launching a simulation go to the `Launcher` init, to minimize duplication in the child `launch_scenario` methods.
  - A new `init_julia` method is added which will start a Julia session in the specified environment and import a given list of Julia packages. To be able to start in a given environment, we need to change the way we start the Julia sessions from `from julia.api import Julia; Julia(compiled_modules=False)` to `from julia.api import LibJulia; api = LibJulia.load(); api.init_julia(["--compiled-modules=no"])`; these are equivalent, see https://pyjulia.readthedocs.io/en/latest/troubleshooting.html#turn-off-compilation-cache. This lets us add another command-line argument to start in a given project folder (environment), see https://julialang.github.io/Pkg.jl/v1.5/environments/#Using-someone-else's-project
  - A new ~`parse_and_return_runtime`~ `parse_runtime` method is added to minimize duplication in the child `launch_scenario` methods.
  - The launcher lookup is fixed so that "GLPK" works, in addition to "glpk"

### Usage Example

First, we'll set up a new Julia environment in an arbitrary folder, and install REISE and GLPK into this environment:
```julia
julia> import Pkg
julia> Pkg.activate(raw"C:\Users\DanielOlsen\repos\bes\scenario_3216\REISE_GLPK")
julia> Pkg.develop(path=raw"C:\Users\DanielOlsen\repos\bes\REISE.jl")
[...install truncated...]
julia> Pkg.add("GLPK")
[...install truncated...]
julia> exit()
```

Then, let's use all of our new command line parameters, executing them inside this new environment:
```
PS C:\Users\DanielOlsen\repos\bes\REISE.jl> python pyreisejl\utility\call.py -s '2016-01-01 00:00:00' -e '2016-01-01 05:00:00' -int 2 -i C:\Users\DanielOlsen\repos\bes\scenario_3216 -j C:\Users\DanielOlsen\repos\bes\scenario_3216\REISE_GLPK -l 3 --solver GLPK
Validation complete!
Launching scenario with parameters:
{'num_segments': 3, 'interval': 2, 'n_interval': 3, 'start_index': 1, 'input_dir': 'C:\\Users\\DanielOlsen\\repos\\bes\\scenario_3216', 'execute_dir': None, 'threads': None, 'julia_env': 'C:\\Users\\DanielOlsen\\repos\\bes\\scenario_3216\\REISE_GLPK', 'solver_kwargs': None}
INFO: threads not supported by GLPK, ignoring
Reading from folder: C:\Users\DanielOlsen\repos\bes\scenario_3216
...loading case.mat
...loading demand.csv
...loading hydro.csv
...loading wind.csv
...loading solar.csv
File case_storage.mat not found in C:\Users\DanielOlsen\repos\bes\scenario_3216
All scenario files loaded!
linearizing
All preparation complete!
Redirecting outputs, see stdout.log & stderr.err in outputfolder
Run time: 0:01:37
```

This works even if GLPK is not installed in your default environment, which you can check with a simple import in fresh julia session:
```julia
julia> import GLPK
ERROR: ArgumentError: Package GLPK not found in current path:
- Run `import Pkg; Pkg.add("GLPK")` to install the GLPK package.
```

### Time to review
30 minutes.