### PR TITLE
Improve docker build caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
 .git
 .pytest_cache
 .tox
+.venv
+Dockerfile
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,10 @@ ENV PATH="$PATH:/usr/share/julia-1.5.3/bin" \
     FLASK_APP=pyreisejl/utility/app.py
 
 WORKDIR /app
-COPY . .
+COPY requirements.txt .
+RUN pip install -U pip; pip install -r requirements.txt
 
+COPY . .
 RUN julia -e 'using Pkg; \
 	Pkg.activate("."); \
 	Pkg.instantiate(); \
@@ -28,8 +30,6 @@ RUN julia -e 'using Pkg; \
 	import Gurobi; \
 	Pkg.add("GLPK"); \
 	import GLPK; \
-	using REISE' && \
-    pip install -r requirements.txt
-
+	using REISE'
 
 CMD ["flask", "run", "--host", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,14 +22,22 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install -U pip; pip install -r requirements.txt
 
-COPY . .
+COPY Project.toml .
+COPY Manifest.toml .
+RUN mkdir src && touch src/REISE.jl
+
 RUN julia -e 'using Pkg; \
 	Pkg.activate("."); \
 	Pkg.instantiate(); \
 	Pkg.add("Gurobi"); \
-	import Gurobi; \
-	Pkg.add("GLPK"); \
+	Pkg.add("GLPK")'
+
+COPY src src
+
+RUN julia -e 'import Gurobi; \
 	import GLPK; \
 	using REISE'
+
+COPY pyreisejl pyreisejl
 
 CMD ["flask", "run", "--host", "0.0.0.0"]


### PR DESCRIPTION
### Purpose
Reduce expected build time by making use of docker caching. We do this by copying just the requirements.txt and toml files earlier in the dockerfile since they change less often, and the bulk of the time is installing julia packages. Adding the code directories later means changes to the code won't invalidate package caches, and we won't need to reinstall packages if they didn't change. For context, each instruction in the dockerfile represents a "layer" of the resulting filesystem, and each layer can be cached, but changes to one layer invalidates the cache for subsequent instructions.

### What it does
Rearranged the dockerfile. I'm pretty sure there is a better way to do this but it works for now.

### Testing
Ran a simulation using both gurobi and glpk with the resulting image. 

### Time to review
5-10 mins 