### PR TITLE
ci: use similar yaml across jobs, simplify naming

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,8 @@ on: push
 
 jobs:
   test-julia:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }}
+    if: "!contains(github.event.head_commit.message, 'skip_ci')"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -14,41 +15,35 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
-        arch:
-          - x64
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
         with:
           path: ~/.julia/artifacts
           key: ${{ runner.os }}-artifacts-${{ hashFiles('**/Project.toml') }}
           restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-artifacts-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
 
   test-python:
+    name: Python ${{ matrix.version }}
     if: "!contains(github.event.head_commit.message, 'skip_ci')"
     runs-on: ubuntu-latest
     strategy:
         fail-fast: false
         matrix:
-          python-version: [3.7, 3.8]
-
-    name: Python ${{ matrix.python-version }}
+          version: [3.7, 3.8]
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.version }}
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.version }}
 
       - run: python -m pip install --upgrade pip tox
       - run: tox -e pytest


### PR DESCRIPTION
Minor improvements:
* remove `arch` from matrix since I don't expect we'll use other values (e.g. x86)
* leave out the os from the job name for now (we can add it back if we start running on more than just ubuntu)
* fix the `restore-keys` list - my understanding is that setting the `cache-name` environment variable is used as an example in the docs to show cases like having multiple caches based on feature branches or some other variable. we aren't partitioning it this way (and I'm not super clear on when that would be useful anyway), so having a hard coded `artifacts` is sufficient. 

Feel free to cherry pick or squash if it looks good.