### PR TITLE
test: reduce noise from flaky test

### DIFF
--- a/pyreisejl/utility/tests/test_state.py
+++ b/pyreisejl/utility/tests/test_state.py
@@ -1,3 +1,4 @@
+import time
 from subprocess import PIPE, Popen
 
 import pytest
@@ -14,6 +15,7 @@ def test_proc():
 
 def test_scenario_state_refresh(test_proc):
     entry = SimulationState(123, test_proc)
+    time.sleep(0.4)  # mitigate race condition
     entry.as_dict()
     assert entry.output == ["foo"]
     assert entry.errors == []


### PR DESCRIPTION
### Purpose
The object being tested involves spawning a process, along with a background thread, so inherently has a race condition. This has been historically semi stable but to prevent noise we have it sleep, to give the background thread some extra time. The duration is arbitrary, just didn't want to make it too long. 

### Testing
Ideally we would measure the failure rate over time, but this will have to be manually observed until there is a way to do that.

### Time to review
30 sec