### PR TITLE
refactor: make api available outside flask context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,9 @@
 .git
+.github
 .pytest_cache
+**/__pycache__
 .tox
+.env
 .venv
 Dockerfile
 .dockerignore

--- a/pyreisejl/utility/app.py
+++ b/pyreisejl/utility/app.py
@@ -1,3 +1,5 @@
+import os
+import sys
 from pathlib import Path
 from subprocess import PIPE, Popen
 
@@ -27,15 +29,23 @@ def get_script_path():
 
 
 def launch_simulation(scenario_id, threads=None, solver=None):
-    cmd_call = ["python3", "-u", get_script_path(), str(scenario_id), "--extract-data"]
+    cmd = [
+        sys.executable,
+        "-u",
+        get_script_path(),
+        str(scenario_id),
+        "--extract-data",
+    ]
 
     if threads is not None:
-        cmd_call.extend(["--threads", str(threads)])
+        cmd.extend(["--threads", str(threads)])
 
     if solver is not None:
-        cmd_call.extend(["--solver", solver])
+        cmd.extend(["--solver", solver])
 
-    proc = Popen(cmd_call, stdout=PIPE, stderr=PIPE, start_new_session=True)
+    new_env = os.environ.copy()
+    new_env["PYTHONPATH"] = str(Path(__file__).parent.parent.parent.absolute())
+    proc = Popen(cmd, stdout=PIPE, stderr=PIPE, start_new_session=True, env=new_env)
     entry = SimulationState(scenario_id, proc)
     state.add(entry)
     return entry.as_dict()

--- a/pyreisejl/utility/const.py
+++ b/pyreisejl/utility/const.py
@@ -1,9 +1,9 @@
-import posixpath
+import os
 
 DATA_ROOT_DIR = "/mnt/bes/pcm"
 
-SCENARIO_LIST = posixpath.join(DATA_ROOT_DIR, "ScenarioList.csv")
-EXECUTE_LIST = posixpath.join(DATA_ROOT_DIR, "ExecuteList.csv")
-EXECUTE_DIR = posixpath.join(DATA_ROOT_DIR, "tmp")
-INPUT_DIR = posixpath.join(DATA_ROOT_DIR, "data", "input")
-OUTPUT_DIR = posixpath.join(DATA_ROOT_DIR, "data", "output")
+SCENARIO_LIST = os.path.join(DATA_ROOT_DIR, "ScenarioList.csv")
+EXECUTE_LIST = os.path.join(DATA_ROOT_DIR, "ExecuteList.csv")
+EXECUTE_DIR = os.path.join(DATA_ROOT_DIR, "tmp")
+INPUT_DIR = os.path.join(DATA_ROOT_DIR, "data", "input")
+OUTPUT_DIR = os.path.join(DATA_ROOT_DIR, "data", "output")

--- a/pyreisejl/utility/const.py
+++ b/pyreisejl/utility/const.py
@@ -1,6 +1,10 @@
 import os
+from pathlib import Path
 
-DATA_ROOT_DIR = "/mnt/bes/pcm"
+if os.getenv("DEPLOYMENT_MODE") is not None:
+    DATA_ROOT_DIR = os.path.join(Path.home(), "ScenarioData", "")
+else:
+    DATA_ROOT_DIR = "/mnt/bes/pcm"
 
 SCENARIO_LIST = os.path.join(DATA_ROOT_DIR, "ScenarioList.csv")
 EXECUTE_LIST = os.path.join(DATA_ROOT_DIR, "ExecuteList.csv")

--- a/pyreisejl/utility/helpers.py
+++ b/pyreisejl/utility/helpers.py
@@ -176,10 +176,8 @@ def get_scenario(scenario_id):
     scenario_info = scenario.to_dict("records", into=OrderedDict)[0]
 
     # Determine input and execute directory for data
-    input_dir = os.path.join(const.EXECUTE_DIR, "scenario_%s" % scenario_info["id"])
-    execute_dir = os.path.join(
-        const.EXECUTE_DIR, f"scenario_{str(scenario_id)}", "output"
-    )
+    input_dir = os.path.join(const.EXECUTE_DIR, f"scenario_{scenario_id}")
+    execute_dir = os.path.join(input_dir, "output")
 
     # Grab start and end date for scenario
     start_date = scenario_info["start_date"]


### PR DESCRIPTION
### Purpose
Enable these functions to be called outside of flask, so a user can launch a simulation and check the status without running the web server, which is mainly useful for communication between containers.

### What it does
Separate the functions from flask  (no route decorator or usage of `jsonify`, which creates an http response object).

By adding the path to REISE.jl to `sys.path`, we can import this module within powersimdata.

### Testing
Ongoing, along with the Breakthrough-Energy/PowerSimData#477

### Time to review
5 mins