### PR TITLE
fix: specify all parameters for DemandFlexibility struct

### DIFF
--- a/src/read.jl
+++ b/src/read.jl
@@ -117,6 +117,9 @@ function read_demand_flexibility(filepath)::DemandFlexibility
         println("Demand flexibility profiles not found in " * filepath)
         demand_flexibility["flex_amt"] = nothing
         demand_flexibility["enabled"] = false
+        demand_flexibility["duration"] = nothing
+        demand_flexibility["interval_balance"] = false
+        demand_flexibility["rolling_balance"] = false
     end
 
     # Set the demand flexibility parameters


### PR DESCRIPTION
### Purpose

The purpose of this code is to fix the error discussed in #129. When a `demand_flexibility.csv` file is not available, not all of the parameters of the `DemandFlexibility` struct were defined.

### What is the code doing?

In the `try/catch` loop that is responsible for trying to load the `demand_flexibility.csv` file in `read_demand_flexibility`, the three parameters that were previously unspecified are now specified.

### Where to look

The fix lives in the `read_demand_flexibility` function in `src/read.jl`.

### Testing

I tested the fix on my local machine and the error presented in #129 no longer occurs. As @BainanXia mentioned, the demand flexibility functionality is not yet integrated into `PowerSimData`, so I cannot be sure that there are not any errors on that end. I also have not tested this with `plug`, which is where the error was first noted. However, based on the error reported in #129, I believe this fix should do the trick.

### Time estimate

This review should be pretty quick.