### PR TITLE
chore: bump version number to v0.2.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "REISE"
 uuid = "b654829c-3c70-409d-9aea-4c9c04976dc6"
 authors = ["Daniel Olsen <daniel.olsen@breakthroughenergy.org>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"


### PR DESCRIPTION
### Purpose

For #132, bump the version number.

### Time to review

5 seconds.