### PR TITLE
Refactor read_demand_flexibility to include duration parameter check

### DIFF
--- a/src/REISE.jl
+++ b/src/REISE.jl
@@ -61,7 +61,7 @@ function run_scenario(;
     stderr_filepath = joinpath(outputfolder, "stderr.err")
     case = read_case(inputfolder)
     storage = read_storage(inputfolder)
-    demand_flexibility = read_demand_flexibility(inputfolder)
+    demand_flexibility = read_demand_flexibility(inputfolder, interval)
     println("All scenario files loaded!")
     case = reise_data_mods(case, num_segments=num_segments)
     save_input_mat(case, storage, inputfolder, outputfolder)

--- a/src/model.jl
+++ b/src/model.jl
@@ -261,18 +261,6 @@ function _build_model(
         bus_demand_flex_amt = _make_bus_demand_flexibility_amount(
             case, demand_flexibility, start_index, end_index
         )
-        if (
-            demand_flexibility.duration == nothing 
-            || demand_flexibility.duration > interval_length
-        )
-            if demand_flexibility.duration > interval_length
-                @warn (
-                    "Demand flexibility durations greater than the interval length are "
-                    * "set equal to the interval length."
-                )
-            end
-            demand_flexibility.duration = interval_length
-        end
     end
 
     println("variables: ", Dates.now())

--- a/src/read.jl
+++ b/src/read.jl
@@ -178,6 +178,17 @@ function read_demand_flexibility(filepath, interval)::DemandFlexibility
                 * "flexibility to occur."
             )
         end
+
+        # Check the feasibility of the duration parameter
+        if demand_flexibility["duration"] == nothing
+            demand_flexibility["duration"] = interval
+        elseif demand_flexibility["duration"] > interval
+            @warn (
+                "Demand flexibility durations greater than the interval length are "
+                * "set equal to the interval length."
+            )
+            demand_flexibility["duration"] = interval
+        end
     end
 
     # Convert Dict to NamedTuple

--- a/src/read.jl
+++ b/src/read.jl
@@ -102,7 +102,7 @@ end
 
 
 """Load demand flexibility profile from .csv files into DataFrame(s)."""
-function read_demand_flexibility(filepath)::DemandFlexibility
+function read_demand_flexibility(filepath, interval)::DemandFlexibility
     # Initialize demand flexibility
     demand_flexibility = Dict()
 
@@ -164,6 +164,12 @@ function read_demand_flexibility(filepath)::DemandFlexibility
                 catch e
                     println(demand_flexibility_params_errs[k])
                 end
+            end
+
+            # Set the demand flexibility constraints to false if enabled is false
+            if !demand_flexibility["enabled"]
+                demand_flexibility["interval_balance"] = false
+                demand_flexibility["rolling_balance"] = false
             end
         catch e
             println("Demand flexibility parameters not found in " * filepath)


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
The goal of this PR to provide a quick refactor and a quick fix to the functionality of `read_demand_flexibility`, found in `read.jl`. Namely, we move the check for the demand flexibility duration parameter to `read.jl` so that there is not a problem with overwriting immutable structs and so that all changes to demand-flexibility-related inputs are kept in one place. We also fix the problem where setting the `enabled` parameter in `demand_flexibility_parameters.csv` to `false` does not set the other demand flexibility constraints to `false`.

### What the code is doing
For the refactor, we move the duration parameter check from `model.jl` to `read_demand_flexibility` in `read.jl`. We also provide a quick fix to the logic in this check so as to not compare `nothing` values with numbers (in the event that occurs). The only other thing that was needed to accomplish this was including an additional input parameter in `read_demand_flexibility` so that the interval length parameter could be specified.

To fix the problem between the `enabled` parameter and the demand flexibility constraints, we include an additional check in `read_demand_flexiblity` after the demand flexibility parameters have been attempted to be read: if `demand_flexiblity["enabled"]` is `false` (as specified by `demand_flexibility_parameters.csv`), then `demand_flexibility["interval_balance"]` and `demand_flexibility["rolling_balance"]` are also set to `false`, regardless of how they are specified in `demand_flexibility_parameters.csv`.

### Testing
I ran a couple local tests to ensure that (1) demand flexibility simulations can be run with only the `demand_flexibility.csv` file present and (2) that setting `enabled` in `demand_flexibility_parameters.csv` to `false` will set the other demand flexibility constraints to `false`.

### Where to look
The majority of this change lives in the `read_demand_flexibility` function in `read.jl`. There is also a small addition to `REISE.jl` (the inclusion of the additional parameter in the `read_demand_flexibility` instance) and a small deletion in `model.jl` (the removal of the duration parameter check).

### Time estimate
This should only take a couple minutes.
