### PR TITLE
Separate demand flexibility profiles for up and down shifting

### DIFF
--- a/src/loop.jl
+++ b/src/loop.jl
@@ -53,7 +53,10 @@ function interval_loop(factory_like, model_kwargs::Dict,
         interval_end = interval_start + interval - 1
         model_kwargs["start_index"] = interval_start
         if demand_flexibility.enabled
-            bus_flex_amt = _make_bus_demand_flexibility_amount(
+            (
+                bus_demand_flex_amt_up, 
+                bus_demand_flex_amt_dn,
+            ) = _make_bus_demand_flexibility_amount(
                 case, demand_flexibility, interval_start, interval_end
             )
         end
@@ -138,10 +141,12 @@ function interval_loop(factory_like, model_kwargs::Dict,
                 end
                 for t in 1:interval, i in 1:length(sets.load_bus_idx)
                     JuMP.set_upper_bound(
-                        m[:load_shift_up][i, t], bus_flex_amt[sets.load_bus_idx[i], t]
+                        m[:load_shift_up][i, t], 
+                        bus_demand_flex_amt_up[sets.load_bus_idx[i], t],
                     )
                     JuMP.set_upper_bound(
-                        m[:load_shift_dn][i, t], bus_flex_amt[sets.load_bus_idx[i], t]
+                        m[:load_shift_dn][i, t], 
+                        bus_demand_flex_amt_dn[sets.load_bus_idx[i], t],
                     )
                     
                     if !isnothing(demand_flexibility.cost_up)

--- a/src/model.jl
+++ b/src/model.jl
@@ -88,7 +88,7 @@ Given a Case object and a DemandFlexibility object, build a matrix of demand fle
 """
 function _make_bus_demand_flexibility_amount(
     case::Case, demand_flexibility::DemandFlexibility, start_index::Int, end_index::Int
-)::Matrix
+)::Tuple{Matrix,Matrix}
     # Bus weighting
     zone_to_bus_shares = _make_bus_demand_weighting(case)
 
@@ -333,9 +333,7 @@ function _add_constraints_demand_flexibility!(
     demand_flexibility::DemandFlexibility,
     interval_length::Int,
 )
-    if demand_flexibility.rolling_balance && (
-        demand_flexibility.duration < interval_length
-    )
+    if demand_flexibility.rolling_balance
         println("rolling load balance: ", Dates.now())
         JuMP.@constraint(
             m,
@@ -673,14 +671,14 @@ function _build_model(
         JuMP.@variable(
             m, 
             0 <= load_shift_dn[i in 1:sets.num_load_bus, j in 1:interval_length] 
-                <= bus_demand_flex_amt_dn[sets.load_bus_idx[i], j]
+                <= bus_demand_flex_amt_dn[sets.load_bus_idx[i], j],
         )
 
         # The amount of demand that is added to the base load
         JuMP.@variable(
             m, 
             0 <= load_shift_up[i in 1:sets.num_load_bus, j in 1:interval_length]
-                <= bus_demand_flex_amt_up[sets.load_bus_idx[i], j]
+                <= bus_demand_flex_amt_up[sets.load_bus_idx[i], j],
         )
     end
 

--- a/src/read.jl
+++ b/src/read.jl
@@ -113,12 +113,12 @@ function read_demand_flexibility(filepath, interval)::DemandFlexibility
     for s in ["up", "dn"]
         try
             demand_flexibility["flex_amt_" * s] = CSV.File(
-                joinpath(filepath, "demand_flexibility_" * s * ".csv"))
+                joinpath(filepath, "demand_flexibility_" * s * ".csv")
             ) |> DataFrames.DataFrame
             println("...loading demand flexibility " * s * " profiles")
         catch e
-            println("Demand flexibility " * s " profile not found in " * filepath)
-            demand_flexibility[string("flex_amt_", s)] = nothing
+            println("Demand flexibility " * s * " profile not found in " * filepath)
+            demand_flexibility["flex_amt_" * s] = nothing
         end
     end
     
@@ -203,7 +203,14 @@ function read_demand_flexibility(filepath, interval)::DemandFlexibility
             )
             demand_flexibility["duration"] = interval
         end
-        
+
+        # Prevent the rolling_balance constraint according to the duration parameter
+        if demand_flexibility["rolling_balance"]
+            if demand_flexibility["duration"] == interval
+                demand_flexibility["rolling_balance"] = false
+            end
+        end
+
         # Try reading the cost for up- and down-shifting loads
         for cost_file_suffix in ("up", "dn")
             try 

--- a/src/read.jl
+++ b/src/read.jl
@@ -128,6 +128,14 @@ function read_demand_flexibility(filepath, interval)::DemandFlexibility
     )
         demand_flexibility["enabled"] = true
     else
+        if !isnothing(demand_flexibility["flex_amt_up"]) || (
+            !isnothing(demand_flexibility["flex_amt_dn"])
+        )
+            @warn (
+                "The exclusion of one of the demand flexibility profiles has resulted "
+                * "in demand flexibility not being enabled."
+            )
+        end
         demand_flexibility["enabled"] = false
         demand_flexibility["duration"] = nothing
         demand_flexibility["interval_balance"] = false

--- a/src/types.jl
+++ b/src/types.jl
@@ -48,7 +48,7 @@ Base.@kwdef struct DemandFlexibility
     flex_amt_dn::Union{DataFrames.DataFrame,Nothing}
     cost_dn::Union{DataFrames.DataFrame,Nothing}
     cost_up::Union{DataFrames.DataFrame,Nothing}
-    duration::Union{Int64,Nothing}
+    duration::Int64
     enabled::Bool
     interval_balance::Bool
     rolling_balance::Bool

--- a/src/types.jl
+++ b/src/types.jl
@@ -44,7 +44,8 @@ end
 
 
 Base.@kwdef struct DemandFlexibility
-    flex_amt::Union{DataFrames.DataFrame,Nothing}
+    flex_amt_up::Union{DataFrames.DataFrame,Nothing}
+    flex_amt_dn::Union{DataFrames.DataFrame,Nothing}
     cost_dn::Union{DataFrames.DataFrame,Nothing}
     cost_up::Union{DataFrames.DataFrame,Nothing}
     duration::Union{Int64,Nothing}


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
The purpose of this PR is to create functionality to read and utilize two demand flexibility profiles: one that bounds the `load_shift_up` variable and another that bounds the `load_shift_dn` variable. This functionality will replace the existing functionality, where one demand flexibility profile is used as the bound for both `load_shift_up` and `load_shift_dn`. This PR closes #139 .

### What the code is doing
The majority of the changes are to the `read_demand_flexibility` function in `read.jl`. Here, the old functionality for reading a single demand flexibility profile has been converted into reading two demand flexibility profiles: `demand_flexibility_up.csv` and `demand_flexibility_dn.csv`. I also include a check that sets the `enabled` parameter to `true` if both demand flexibility profiles are present and `false` otherwise; `demand_flexibility_up.csv` not being present prevents demand recovery (since this is shiftable demand) and `demand_flexibility_dn.csv` not being present prevents curtailment. As mentioned in #139, if we want the ability to have sheddable demand, we should probably revisit #125. Also included in `read_demand_flexibility` is a small refactor that sets the `rolling_balance` parameter to `false` if the `duration` parameter equals the interval length; this refactor helps clean up some of the checks in `model.jl`.

The `DemandFlexibility` struct in `types.jl` is updated to replace the `flex_amt` parameters with `flex_amt_up` and `flex_amt_dn`.

In `model.jl`, the `_make_bus_demand_flexibility_amount` function was updated to be able to pass out two bus-level demand flexibility arrays. Both `model.jl` and `loop.jl` (1) reflect this change to `_make_bus_demand_flexibility_amount` and (2) feature updates to the upper bounds of the `load_shift_up` and `load_shift_dn` variables.

### Testing
Testing was conducted locally on the provided Texas data. The Texas data needed to be changed so that the old `demand_flexibility.csv` file is replaced by `demand_flexibility_up.csv` and `demand_flexibility_dn.csv`. For testing purposes, both `demand_flexibility_up.csv` and `demand_flexibility_dn.csv` are the same as `demand_flexibility.csv`. Under this definition of testing profiles, the results under the new implementation were the same as those under the old implementation.

### Where to look
The changes are contained in the following:
- The `interval_loop` function in `loop.jl`
- The `_make_bus_demand_flexibility_amount`, `_add_constraints_demand_flexibility!`, and `_build_model` functions in `model.jl`
- The `read_demand_flexibility` function in `read.jl`
- The `DemandFlexibility` struct in `types.jl`

### Time estimate
This hopefully shouldn't take too long to review as most of the changes are straightforward. Maybe 15 minutes?
