### PR TITLE
feat: allow extract-data to be specified through api

### DIFF
--- a/pyreisejl/utility/app.py
+++ b/pyreisejl/utility/app.py
@@ -11,44 +11,72 @@ app = Flask(__name__)
 
 
 """
-Example request:
+Example requests:
 
-curl -XPOST http://localhost:5000/launch/1234
-curl -XPOST http://localhost:5000/launch/1234?threads=4&solver=glpk
-curl http://localhost:5000/status/1234
+Launch using gurobi, 4 threads, auto extract
+curl -XPOST http://localhost:5000/launch/123?threads=4
+
+Launch using GLPK, extract manually
+curl -XPOST http://localhost:5000/launch/123?solver=glpk&extract-data=0
+curl -XPOST http://localhost:5000/extract/123
+
+Check status of scenario 123
+curl http://localhost:5000/status/123
 """
 
 
 state = ApplicationState()
 
 
-def get_script_path():
+def get_script_path(filename):
     script_dir = Path(__file__).parent.absolute()
-    path_to_script = Path(script_dir, "call.py")
+    path_to_script = Path(script_dir, filename)
     return str(path_to_script)
 
 
-def launch_simulation(scenario_id, threads=None, solver=None):
+def call_cmd(scenario_id, threads=None, solver=None, extract=True):
     cmd = [
         sys.executable,
         "-u",
-        get_script_path(),
+        get_script_path("call.py"),
         str(scenario_id),
-        "--extract-data",
     ]
-
+    if extract:
+        cmd.extend(["--extract-data"])
     if threads is not None:
         cmd.extend(["--threads", str(threads)])
-
     if solver is not None:
         cmd.extend(["--solver", solver])
+    return cmd
 
+
+def extract_cmd(scenario_id):
+    cmd = [
+        sys.executable,
+        "-u",
+        get_script_path("extract_data.py"),
+        str(scenario_id),
+    ]
+    return cmd
+
+
+def run_script(cmd, scenario_id):
     new_env = os.environ.copy()
     new_env["PYTHONPATH"] = str(Path(__file__).parent.parent.parent.absolute())
     proc = Popen(cmd, stdout=PIPE, stderr=PIPE, start_new_session=True, env=new_env)
     entry = SimulationState(scenario_id, proc)
     state.add(entry)
     return entry.as_dict()
+
+
+def launch_simulation(scenario_id, threads=None, solver=None, extract=True):
+    cmd = call_cmd(scenario_id, threads, solver, extract)
+    return run_script(cmd, scenario_id)
+
+
+def extract_scenario(scenario_id):
+    cmd = extract_cmd(scenario_id)
+    return run_script(cmd, scenario_id)
 
 
 def check_progress():
@@ -59,7 +87,15 @@ def check_progress():
 def handle_launch(scenario_id):
     threads = request.args.get("threads", None)
     solver = request.args.get("solver", None)
-    entry = launch_simulation(scenario_id, threads, solver)
+    extract_arg = request.args.get("extract-data", None)
+    extract = extract_arg is not None and extract_arg not in ("0", "False")
+    entry = launch_simulation(scenario_id, threads, solver, extract)
+    return jsonify(entry)
+
+
+@app.route("/extract/<int:scenario_id>", methods=["POST"])
+def handle_extract(scenario_id):
+    entry = extract_scenario(scenario_id)
     return jsonify(entry)
 
 


### PR DESCRIPTION
### Purpose
Extend the flask api and underlying functions that are called in a container environment and locally, so that `--extract-data` can be passed to `call.py`, and the extraction can be done manually. This makes the interface consistent across server/container/local environments. Original motivation is to allow launching a bunch of scenarios in parallel, but serializing the extraction step to avoid race conditions. See https://github.com/Breakthrough-Energy/plug/issues/23. 

### What the code is doing
Some refactoring to reuse existing code, but mostly wiring things together.

### Testing
Created and launched a simulation in a container and on my local machine.  Also tested launching one with `scenario.launch_simulation(solver="clp", extract_data=False)` and got expected results.

### Time estimate
10 min
