### PR TITLE
chore: install Clp via Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,12 +29,14 @@ RUN mkdir src && touch src/REISE.jl
 RUN julia -e 'using Pkg; \
 	Pkg.activate("."); \
 	Pkg.instantiate(); \
+	Pkg.add("GLPK"); \
 	Pkg.add("Gurobi"); \
-	Pkg.add("GLPK")'
+	Pkg.add("Clp")'
 
 COPY src src
 
 RUN julia -e 'import Gurobi; \
+	import Clp; \
 	import GLPK; \
 	using REISE'
 


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Follow-up to #148, add the install and import of `Clp.jl` via Docker.

### What the code is doing
Copy-paste the GLPK lines. Clp should auto-install the binaries in the same way.

### Testing
Not tested.

### Time estimate
2 minutes.
