### PR TITLE
feat: add demand flexibility cost

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -499,6 +499,7 @@ function _add_objective_function!(
     load_shed_penalty::Number,
     trans_viol_enabled::Bool,
     storage_e0::Array{Float64,1},
+    demand_flexibility::DemandFlexibility,
 )
     # Positional indices from mpc.gencost
     COST = 5

--- a/src/read.jl
+++ b/src/read.jl
@@ -194,6 +194,21 @@ function read_demand_flexibility(filepath, interval)::DemandFlexibility
             )
             demand_flexibility["duration"] = interval
         end
+        
+        # Try reading the cost for up- and down-shifting loads
+        for cost_file_suffix in ("up", "dn")
+            try 
+                demand_flexibility["cost_$cost_file_suffix"] = CSV.File(
+                    joinpath(filepath, "demand_flexibility_cost_$cost_file_suffix.csv")
+                ) |> DataFrames.DataFrame
+                println("...loading demand flexibility $cost_file_suffix-shift cost profiles")
+            catch e
+                println(
+                    "Demand flexibility down-shift cost profiles not found in " * filepath
+                )
+                demand_flexibility["cost_$cost_file_suffix"] = nothing
+            end
+        end
     end
 
     # Convert Dict to NamedTuple

--- a/src/read.jl
+++ b/src/read.jl
@@ -123,9 +123,11 @@ function read_demand_flexibility(filepath, interval)::DemandFlexibility
         demand_flexibility["duration"] = nothing
         demand_flexibility["interval_balance"] = false
         demand_flexibility["rolling_balance"] = false
+        demand_flexibility["cost_up"] = nothing
+        demand_flexibility["cost_dn"] = nothing
     end
 
-    # Set the demand flexibility parameters
+    # Set the demand flexibility costs and parameters
     if demand_flexibility["enabled"]
         # Pre-specify the demand flexibility parameters
         demand_flexibility["duration"] = nothing

--- a/src/types.jl
+++ b/src/types.jl
@@ -45,6 +45,8 @@ end
 
 Base.@kwdef struct DemandFlexibility
     flex_amt::Union{DataFrames.DataFrame,Nothing}
+    cost_dn::Union{DataFrames.DataFrame,Nothing}
+    cost_up::Union{DataFrames.DataFrame,Nothing}
     duration::Union{Int64,Nothing}
     enabled::Bool
     interval_balance::Bool


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Update demand flexibility cost code in #135 to accommodate the changes in #142.  Consolidate comments from @lanesmith 
Respond to comments in PR #147 (closed accidentally)

### What the code is doing
* The code attempts to read two additional input files `demand_flexibility_cost_up.csv` and `demand_flexibility_cost_up.csv` and create corresponding fields in the DemandFlexibility class
* The numeric costs are added to the decision variables `load_shift_up` and `load_shift_dn`

### Testing
The code is setup on a local computer and uses a ERCOT sub-system to reduce computation time
The code is tested using dummy input files (shared in slack channel) and when inputs files are missing
The results with/without the cost input files are checked and compared
Various testing are performed using interval length and interval number ranging from 1 to 3 

### Where to look
* It's helpful to clarify where your new code lives if you moved files around or there could be confusion/

* two fields in types.jl
* csv reading code in read.jl
* add corresponding objective function expression in model.jl
* re-assign coefficients in loop.jl

### Usage Example/Visuals
N/A

### Time estimate
~15 min for people that are familiar with the previous version in #147
