### PR TITLE
refactor: improve error messaging for Gurobi environment issues

### DIFF
--- a/src/solver_specific/gurobi.jl
+++ b/src/solver_specific/gurobi.jl
@@ -6,12 +6,17 @@ function run_scenario_gurobi(; solver_kwargs::Union{Dict, Nothing}=nothing, kwar
     solver_kwargs = something(solver_kwargs, Dict("Method" => 2, "Crossover" => 0))
     try
         global env = Gurobi.Env()
+    catch e
+        println("Error encountered starting Gurobi.")
+        throw(e)
+    end
+    try
         global m = run_scenario(;
             optimizer_factory=env, solver_kwargs=solver_kwargs, kwargs...)
     finally
         Gurobi.finalize(JuMP.backend(m))
         Gurobi.finalize(env)
-        println("Connection closed successfully!")
+        println("Connection to Gurobi closed successfully!")
     end
     # Return `nothing` to prevent `m` from the `try` block from being returned
     return nothing


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Currently, if there is an error in setting up a Gurobi environment (e.g. if a Gurobi license file is not present), then calling `Gurobi.Env()` will fail, and the JuMP model that would get stored in the variable `m` will not get created, and will not be available when we try to clean up the model and the connection to Gurobi with the `finalize` commands in the `finally` block, which will cause an error with the variable not being defined.

### What the code is doing
More `try`/`catch` branching, so that if Gurobi fails (rather than something in model building/execution step) we return that error right away.

### Testing
Running from the command-line using *call.py*, before:
```
JULIA: UndefVarError: m not defined
Stacktrace:
 [1] run_scenario_gurobi(; solver_kwargs::Nothing, kwargs::Base.Iterators.Pairs{Symbol,Any,NTuple{7,Symbol},NamedTuple{(:interval, :n_interval, :start_index, :inputfolder, :outputfolder, :threads, :num_segments),Tuple{Int64,Int64,Int64,String,Nothing,Nothing,Int64}}}) at C:\Users\DanielOlsen\repos\bes\REISE.jl\src\solver_specific\gurobi.jl:12
 [2] (::Base.var"#inner#2"{Base.Iterators.Pairs{Symbol,Any,NTuple{8,Symbol},NamedTuple{(:interval, :n_interval, :start_index, :inputfolder, :outputfolder, :threads, :solver_kwargs, :num_segments),Tuple{Int64,Int64,Int64,String,Nothing,Nothing,Nothing,Int64}}},typeof(REISE.run_scenario_gurobi),Tuple{}})() at .\essentials.jl:713
 [3] #invokelatest#1 at .\essentials.jl:714 [inlined]
 [4] _pyjlwrap_call(::Function, ::Ptr{PyCall.PyObject_struct}, ::Ptr{PyCall.PyObject_struct}) at C:\Users\DanielOlsen\.julia\packages\PyCall\BD546\src\callback.jl:32
 [5] pyjlwrap_call(::Ptr{PyCall.PyObject_struct}, ::Ptr{PyCall.PyObject_struct}, ::Ptr{PyCall.PyObject_struct}) at C:\Users\DanielOlsen\.julia\packages\PyCall\BD546\src\callback.jl:44>
```

after (no license file):
```
Error encountered starting Gurobi.
<PyCall.jlwrap (in a Julia function called from Python)
JULIA: Gurobi Error 10009: No Gurobi license found (user danielolsen, host BE-003412401557, hostid b64e83e1, cores 4)
Stacktrace:
 [1] run_scenario_gurobi(; solver_kwargs::Nothing, kwargs::Base.Iterators.Pairs{Symbol,Any,NTuple{7,Symbol},NamedTuple{(:interval, :n_interval, :start_index, :inputfolder, :outputfolder, :threads, :num_segments),Tuple{Int64,Int64,Int64,String,Nothing,Nothing,Int64}}}) at C:\Users\DanielOlsen\repos\bes\REISE.jl\src\solver_specific\gurobi.jl:11
 [2] (::Base.var"#inner#2"{Base.Iterators.Pairs{Symbol,Any,NTuple{8,Symbol},NamedTuple{(:interval, :n_interval, :start_index, :inputfolder, :outputfolder, :threads, :solver_kwargs, :num_segments),Tuple{Int64,Int64,Int64,String,Nothing,Nothing,Nothing,Int64}}},typeof(REISE.run_scenario_gurobi),Tuple{}})() at .\essentials.jl:713
 [3] #invokelatest#1 at .\essentials.jl:714 [inlined]
 [4] _pyjlwrap_call(::Function, ::Ptr{PyCall.PyObject_struct}, ::Ptr{PyCall.PyObject_struct}) at C:\Users\DanielOlsen\.julia\packages\PyCall\BD546\src\callback.jl:32
 [5] pyjlwrap_call(::Ptr{PyCall.PyObject_struct}, ::Ptr{PyCall.PyObject_struct}, ::Ptr{PyCall.PyObject_struct}) at C:\Users\DanielOlsen\.julia\packages\PyCall\BD546\src\callback.jl:44>
```

When the license file is there, everything still proceeds as expected.

### Time estimate
5 minutes.
