### PR TITLE
fix: define interval length for load shed constraint function

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -245,6 +245,7 @@ function _add_constraint_load_shed!(
     demand_flexibility::DemandFlexibility,
     bus_demand::Matrix,
 )
+    interval_length = size(bus_demand)[2]
     demand_for_load_shed = JuMP.@expression(
         m,
         [i=1:sets.num_load_bus, j=1:interval_length],


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Fix a bug introduced in #142, in which the `interval_length` variable is not defined within the `_add_constraint_load_shed!` function.

### What the code is doing
Defining the variable, based on the dimensions of the existing bus_demand input.

### Testing
In progress.

### Time estimate
2 minutes.
