### PR TITLE
Pass net demand deviations to the next interval

### DIFF
--- a/src/loop.jl
+++ b/src/loop.jl
@@ -66,15 +66,9 @@ function interval_loop(factory_like, model_kwargs::Dict,
                 model_kwargs["storage_e0"] = storage.sd_table.InitialStorage
             end
             if demand_flexibility.enabled
-                try
-                    model_kwargs["init_shifted_demand"] = zeros(
-                        size(bus_demand_flex_amt_dn, 1)
-                    )
-                catch e
-                    model_kwargs["init_shifted_demand"] = zeros(
-                        size(bus_demand_flex_amt_up, 1)
-                    )
-                end
+                model_kwargs["init_shifted_demand"] = zeros(
+                    size(bus_demand_flex_amt_dn, 1)
+                )
             end
             m = new_model(factory_like)
             JuMP.set_optimizer_attributes(m, pairs(solver_kwargs)...)

--- a/src/loop.jl
+++ b/src/loop.jl
@@ -265,10 +265,13 @@ function interval_loop(factory_like, model_kwargs::Dict,
         end
         if demand_flexibility.enabled
             if demand_flexibility.interval_balance || demand_flexibility.rolling_balance
-                init_shifted_demand = sum(
-                    results.load_shift_up - results.load_shift_dn,
-                    dims=2
-                )[:, 1]
+                init_shifted_demand = dropdims(
+                    sum(results.load_shift_up - results.load_shift_dn, dims=2); dims=2
+                )
+            else
+                init_shifted_demand = zeros(
+                    size(bus_demand_flex_amt_dn, 1)
+                )
             end
         end
 

--- a/src/loop.jl
+++ b/src/loop.jl
@@ -66,7 +66,7 @@ function interval_loop(factory_like, model_kwargs::Dict,
                 model_kwargs["storage_e0"] = storage.sd_table.InitialStorage
             end
             if demand_flexibility.enabled
-                model_kwargs["init_shifted_demand"] = zeros(size(bus_flex_amt, 2))
+                model_kwargs["init_shifted_demand"] = zeros(size(bus_flex_amt, 1))
             end
             m = new_model(factory_like)
             JuMP.set_optimizer_attributes(m, pairs(solver_kwargs)...)
@@ -267,12 +267,12 @@ function interval_loop(factory_like, model_kwargs::Dict,
                         :, (interval - demand_flexibility.duration + 1):end
                     ],
                     dims=2
-                )
+                )[:, 1]
             else
                 init_shifted_demand = sum(
                     results.load_shift_up - results.load_shift_dn,
                     dims=2
-                )
+                )[:, 1]
             end
         end
 

--- a/src/loop.jl
+++ b/src/loop.jl
@@ -46,7 +46,7 @@ function interval_loop(factory_like, model_kwargs::Dict,
     # Start looping
     for i in 1:n_interval
         # These must be declared global so that they persist through the loop.
-        global m, pg0, storage_e0, intervals_without_loadshed
+        global m, pg0, storage_e0, init_shifted_demand, intervals_without_loadshed
         @show ("load_shed_enabled" in keys(model_kwargs))
         @show ("BarHomogeneous" in keys(solver_kwargs))
         interval_start = start_index + (i - 1) * interval
@@ -65,6 +65,9 @@ function interval_loop(factory_like, model_kwargs::Dict,
             if storage.enabled
                 model_kwargs["storage_e0"] = storage.sd_table.InitialStorage
             end
+            if demand_flexibility.enabled
+                model_kwargs["init_shifted_demand"] = zeros(size(bus_flex_amt, 2))
+            end
             m = new_model(factory_like)
             JuMP.set_optimizer_attributes(m, pairs(solver_kwargs)...)
             m = _build_model(m; symbolize(model_kwargs)...)
@@ -74,6 +77,9 @@ function interval_loop(factory_like, model_kwargs::Dict,
             model_kwargs["initial_ramp_g0"] = pg0
             if storage.enabled
                 model_kwargs["storage_e0"] = storage_e0
+            end
+            if demand_flexibility.enabled
+                model_kwargs["init_shifted_demand"] = init_shifted_demand
             end
             m = new_model(factory_like)
             JuMP.set_optimizer_attributes(m, pairs(solver_kwargs)...)
@@ -139,26 +145,37 @@ function interval_loop(factory_like, model_kwargs::Dict,
                         )
                     )
                 end
-                for t in 1:interval, i in 1:sets.num_flexible_bus
-                    JuMP.set_upper_bound(
-                        m[:load_shift_up][i, t], 
-                        bus_demand_flex_amt_up[i, t],
-                    )
-                    JuMP.set_upper_bound(
-                        m[:load_shift_dn][i, t], 
-                        bus_demand_flex_amt_dn[i, t],
-                    )
-                    
-                    if !isnothing(demand_flexibility.cost_up)
-                        JuMP.set_objective_coefficient(
-                            m, m[:load_shift_up][i, t], bus_demand_flex_cost_up[i, t]
+                for i in 1:sets.num_flexible_bus
+                    for t in 1:interval
+                        JuMP.set_upper_bound(
+                            m[:load_shift_up][i, t], 
+                            bus_demand_flex_amt_up[i, t],
                         )
-                    end
-                    if !isnothing(demand_flexibility.cost_dn)
-                        JuMP.set_objective_coefficient(
-                            m, m[:load_shift_dn][i, t], bus_demand_flex_cost_dn[i, t]
+                        JuMP.set_upper_bound(
+                            m[:load_shift_dn][i, t], 
+                            bus_demand_flex_amt_dn[i, t],
                         )
+                        if !isnothing(demand_flexibility.cost_up)
+                            JuMP.set_objective_coefficient(
+                                m, 
+                                m[:load_shift_up][i, t], 
+                                bus_demand_flex_cost_up[i, t],
+                            )
+                        end
+                        if !isnothing(demand_flexibility.cost_dn)
+                            JuMP.set_objective_coefficient(
+                                m, 
+                                m[:load_shift_dn][i, t], 
+                                bus_demand_flex_cost_dn[i, t],
+                            )
+                        end
                     end
+                    JuMP.set_normalized_rhs(
+                        m[:rolling_load_balance_first][i], -1 * init_shifted_demand[i]
+                    )
+                    JuMP.set_normalized_rhs(
+                        m[:interval_load_balance][i], -1 * init_shifted_demand[i]
+                    )
                 end
             end
         end
@@ -234,6 +251,25 @@ function interval_loop(factory_like, model_kwargs::Dict,
         pg0 = results.pg[:,end]
         if storage.enabled
             storage_e0 = results.storage_e[:,end]
+        end
+        if demand_flexibility.enabled
+            if demand_flexibility.rolling_balance && (
+                demand_flexibility.duration < interval
+            )
+                init_shifted_demand = sum(
+                    results.load_shift_up[
+                        :, (interval - demand_flexibility.duration + 1):end
+                    ] - results.load_shift_dn[
+                        :, (interval - demand_flexibility.duration + 1):end
+                    ],
+                    dims=2
+                )
+            else
+                init_shifted_demand = sum(
+                    results.load_shift_up - results.load_shift_dn,
+                    dims=2
+                )
+            end
         end
 
         # Save results

--- a/src/loop.jl
+++ b/src/loop.jl
@@ -134,47 +134,51 @@ function interval_loop(factory_like, model_kwargs::Dict,
                 if !isnothing(demand_flexibility.cost_up)
                     bus_demand_flex_cost_up = permutedims(
                         Matrix(
-                            demand_flexibility.cost_up[interval_start:interval_end, 2:end]
+                            demand_flexibility.cost_up[
+                                interval_start:interval_end, 2:end
+                            ]
                         )
                     )
                 end
                 if !isnothing(demand_flexibility.cost_dn)
                     bus_demand_flex_cost_dn = permutedims(
                         Matrix(
-                            demand_flexibility.cost_dn[interval_start:interval_end, 2:end]
+                            demand_flexibility.cost_dn[
+                                interval_start:interval_end, 2:end
+                            ]
                         )
                     )
                 end
-                for i in 1:sets.num_flexible_bus
+                for l in 1:sets.num_flexible_bus
                     for t in 1:interval
                         JuMP.set_upper_bound(
-                            m[:load_shift_up][i, t], 
-                            bus_demand_flex_amt_up[i, t],
+                            m[:load_shift_up][l, t], 
+                            bus_demand_flex_amt_up[l, t],
                         )
                         JuMP.set_upper_bound(
-                            m[:load_shift_dn][i, t], 
-                            bus_demand_flex_amt_dn[i, t],
+                            m[:load_shift_dn][l, t], 
+                            bus_demand_flex_amt_dn[l, t],
                         )
                         if !isnothing(demand_flexibility.cost_up)
                             JuMP.set_objective_coefficient(
                                 m, 
-                                m[:load_shift_up][i, t], 
-                                bus_demand_flex_cost_up[i, t],
+                                m[:load_shift_up][l, t], 
+                                bus_demand_flex_cost_up[l, t],
                             )
                         end
                         if !isnothing(demand_flexibility.cost_dn)
                             JuMP.set_objective_coefficient(
                                 m, 
-                                m[:load_shift_dn][i, t], 
-                                bus_demand_flex_cost_dn[i, t],
+                                m[:load_shift_dn][l, t], 
+                                bus_demand_flex_cost_dn[l, t],
                             )
                         end
                     end
                     JuMP.set_normalized_rhs(
-                        m[:rolling_load_balance_first][i], -1 * init_shifted_demand[i]
+                        m[:rolling_load_balance_first][l], -1 * init_shifted_demand[l]
                     )
                     JuMP.set_normalized_rhs(
-                        m[:interval_load_balance][i], -1 * init_shifted_demand[i]
+                        m[:interval_load_balance][l], -1 * init_shifted_demand[l]
                     )
                 end
             end

--- a/src/model.jl
+++ b/src/model.jl
@@ -394,7 +394,9 @@ function _add_constraints_demand_flexibility!(
             m,
             interval_load_balance[i in 1:sets.num_flexible_bus],
             sum(
-                m[:load_shift_up][i, j] - m[:load_shift_dn][i, j] for j in 1:interval_length
+                m[:load_shift_up][i, j] 
+                - m[:load_shift_dn][i, j] 
+                for j in 1:interval_length
             ) >= -1 * init_shifted_demand[i],
         )
     end
@@ -740,7 +742,7 @@ function _build_model(
 
     if demand_flexibility.enabled
         _add_constraints_demand_flexibility!(
-            m, case, sets, demand_flexibility, interval_length
+            m, case, sets, demand_flexibility, interval_length, init_shifted_demand
         )
     end
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -380,11 +380,11 @@ function _add_constraints_demand_flexibility!(
             m,
             rolling_load_balance[
                 i in 1:sets.num_flexible_bus,
-                k in 1:(interval_length - demand_flexibility.duration)
+                k in 1:(interval_length - demand_flexibility.duration + 1)
             ],
             sum(
                 m[:load_shift_up][i, j] - m[:load_shift_dn][i, j]
-                for j in k:(k + demand_flexibility.duration)
+                for j in k:(k + demand_flexibility.duration - 1)
             ) >= 0,
         )
     end

--- a/src/model.jl
+++ b/src/model.jl
@@ -363,8 +363,18 @@ function _add_constraints_demand_flexibility!(
     sets::Sets,
     demand_flexibility::DemandFlexibility,
     interval_length::Int,
+    init_shifted_demand::Array{Float64,1}=Float64[],
 )
     if demand_flexibility.rolling_balance
+        println("rolling load balance, first window: ", Dates.now())
+        JuMP.@constraint(
+            m,
+            rolling_load_balance_first[i in 1:sets.num_load_bus],
+            sum(
+                m[:load_shift_up][i, j] - m[:load_shift_dn][i, j] 
+                for j in 1:(demand_flexibility.duration - 1)
+            ) >= -1 * init_shifted_demand[i],
+        )
         println("rolling load balance: ", Dates.now())
         JuMP.@constraint(
             m,
@@ -385,7 +395,7 @@ function _add_constraints_demand_flexibility!(
             interval_load_balance[i in 1:sets.num_flexible_bus],
             sum(
                 m[:load_shift_up][i, j] - m[:load_shift_dn][i, j] for j in 1:interval_length
-            ) >= 0,
+            ) >= -1 * init_shifted_demand[i],
         )
     end
 end
@@ -634,7 +644,8 @@ function _build_model(
     trans_viol_penalty::Number=100,
     initial_ramp_enabled::Bool=false,
     initial_ramp_g0::Array{Float64,1}=Float64[],
-    storage_e0::Array{Float64,1}=Float64[]
+    storage_e0::Array{Float64,1}=Float64[],
+    init_shifted_demand::Array{Float64,1}=Float64[]
 )::JuMP.Model
     # Positional indices from mpc.gen
     PMAX = 9


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
The purpose of this feature is to pass net demand deviations from the current interval to the following interval. Based on the demand flexibility formulation, shifted demand does not necessarily need to be completely balanced at the end of an interval (though it likely will be due to the cost minimizing objective). This feature ensures that all shifted demand ends up being accounted for. This PR closes #123.

### What the code is doing
In `model.jl`, a new constraint (`rolling_load_balance_first`) is added to account for the previous interval's net demand deviation during instances where the `rolling_balance` parameter is enabled. This new constraint creates an additional rolling window at the beginning of the interval to balance demand deviations and the previous interval's net demand deviation. Additionally, the `interval_load_balance` constraint is updated to account for the net demand deviation. There is also a small fix to the number of rolling windows that are used in the `rolling_load_balance` constraint. Previous iterations of the model did not accurately account for the number of balancing periods that should be present.

In `loop.jl`, the net demand deviation is calculated and passed to the following interval. This implementation is similar to that of the initial state of charge parameter used in the energy storage model. Net demand deviations are calculated as the difference between the up and down deviations for each bus with demand flexibility for each interval. The `interval_load_balance` and `rolling_load_balance_first` constraints are also updated appropriately for intervals `i > 2`.

### Testing
I tested this on the iteration of the ERCOT grid that we have been using for testing. When testing on 3 intervals of 24 hours each, net demand deviations are passed to the following interval without issue.

### Where to look
Changes are contained within `model.jl` and `loop.jl`.

### Time estimate
This hopefully shouldn't take too long to review. A good chunk of the noted changes are due to how the demand flexibility constraints and variables are updated in `loop.jl`. No functionality is changed, just how they are set in the for loops.
