### PR TITLE
feat: allow optional bus-level demand flexibility and cost

### DIFF
--- a/src/query.jl
+++ b/src/query.jl
@@ -3,9 +3,9 @@
 
 Extract the results of a simulation, store in a struct.
 """
-function get_results(f::Float64, case::Case)::Results
+function get_results(f::Float64, case::Case, demand_flexibility::DemandFlexibility)::Results
     status = "OPTIMAL"
-    sets = _make_sets(case)
+    sets = _make_sets(case, nothing, demand_flexibility)
     # These variables will always be in the results
     pg = JuMP.value.(m[:pg])
     pf = JuMP.value.(m[:pf])
@@ -69,8 +69,8 @@ function get_results(f::Float64, case::Case)::Results
     try
         load_shift_up_temp = JuMP.value.(m[:load_shift_up])
         load_shift_dn_temp = JuMP.value.(m[:load_shift_dn])
-        load_shift_up = sets.load_bus_map * load_shift_up_temp
-        load_shift_dn = sets.load_bus_map * load_shift_dn_temp
+        load_shift_up = sets.flexible_load_bus_map * load_shift_up_temp
+        load_shift_dn = sets.flexible_load_bus_map * load_shift_dn_temp
     catch e
         if isa(e, KeyError)
             # Thrown when load shift variables are `nothing`

--- a/src/read.jl
+++ b/src/read.jl
@@ -117,6 +117,7 @@ function read_demand_flexibility(filepath, interval)::DemandFlexibility
         "enabled" => "not_specified",  
         "interval_balance" => true, 
         "rolling_balance" => true,
+        "input_granularity" => "AREA",
     )
 
     # Try loading the demand flexibility parameters
@@ -145,6 +146,11 @@ function read_demand_flexibility(filepath, interval)::DemandFlexibility
             "rolling_balance" => (
                 "The parameter that indicates if the rolling load balance constraint "
                 * "is enabled is not defined. Will default to being enabled."
+            ),
+            "input_granularity" => (
+                "The parameter that indicates the way demand flexibility "
+                * "and demand flexibility cost are provided is not defined. "
+                * "Will default to being area-based."
             ),
         )
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -52,6 +52,7 @@ Base.@kwdef struct DemandFlexibility
     enabled::Bool
     interval_balance::Bool
     rolling_balance::Bool
+    input_granularity::String
 end
 
 
@@ -102,6 +103,10 @@ Base.@kwdef struct Sets
     # Segments
     num_segments::Int64
     segment_idx::UnitRange{Int64}
+    ## Demand Flexibility
+    flexible_bus_idx::Union{Array{Int64,1}, Nothing}
+    num_flexible_bus::Int64
+    flexible_load_bus_map::Union{SparseMatrixCSC, Nothing}
     # Storage
     num_storage::Int64
     storage_idx::Union{UnitRange{Int64},Nothing}


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Implement functionalities related to issue #141

### What the code is doing
Compare to the main branch, this version does the following:
* read a new string variable that is either "AREA" or "BUS" from the parameter csv
* if "AREA", do exactly the same thing as the active main branch
* if "BUS", the code look for the buses (columns in input demand_flexibility_up/dn.csv) and create decision variables and constraints only for the buses with a specify flexibility

### Testing
Testing both functions and the entire REISE program using dummy input
The numerical result coming out of the program is not yet analyzed
 
### Where to look
* type.jl -- definition of Sets and DemandFlexibility
* loop.jl -- minor change
* read.jl -- read one additional parameter from input csv
* model.jl -- many functions changed to accommodate the new functionality

### Usage Example/Visuals

### Time estimate
~45 min