### PR TITLE
fix: _make_sets invocation

### DIFF
--- a/src/loop.jl
+++ b/src/loop.jl
@@ -44,7 +44,7 @@ function interval_loop(
     case = model_kwargs["case"]
     storage = model_kwargs["storage"]
     demand_flexibility = model_kwargs["demand_flexibility"]
-    sets = _make_sets(case, storage, demand_flexibility)
+    sets = _make_sets(case; storage=storage, demand_flexibility=demand_flexibility)
     unused_load_shed_intervals_turnoff = 14
     # Start looping
     for i in 1:n_interval

--- a/src/model.jl
+++ b/src/model.jl
@@ -643,7 +643,7 @@ function _build_model(
     hour_idx = 1:interval_length
     end_index = start_index + interval_length - 1
     # Sets - static
-    sets = _make_sets(case, storage, demand_flexibility)
+    sets = _make_sets(case; storage=storage, demand_flexibility=demand_flexibility)
     println("parameters: ", Dates.now())
     # Parameters
     bus_demand = _make_bus_demand(case, start_index, end_index) * demand_scaling

--- a/src/query.jl
+++ b/src/query.jl
@@ -5,7 +5,7 @@ Extract the results of a simulation, store in a struct.
 """
 function get_results(f::Float64, case::Case, demand_flexibility::DemandFlexibility)::Results
     status = "OPTIMAL"
-    sets = _make_sets(case, nothing, demand_flexibility)
+    sets = _make_sets(case; storage=nothing, demand_flexibility=demand_flexibility)
     # These variables will always be in the results
     pg = JuMP.value.(m[:pg])
     pf = JuMP.value.(m[:pf])


### PR DESCRIPTION
### Purpose
Attempt to fix an error we get launching a simulation. This is the (truncated) output from `scenario.check_progress()` 
```
  'Julia exception: MethodError: no method matching _make_sets(::REISE.Case, ::REISE.Storage, ::REISE.DemandFlexibility)',
  'Closest candidates are:',
  '_make_sets(::REISE.Case; storage, demand_flexibility) at /app/src/model.jl:133',
  'Stacktrace:',
  '[1] interval_loop(::Type{T} where T, ::Dict{String,Any}, ::Dict{Any,Any}, ::Int64, ::Int64, ::Int64, ::String, ::String) at /app/src/loop.jl:47',
  '[2] (::REISE.var"#116#117"{Int64,Int64,Int64,String,DataType,Dict{String,Any}})() at /app/src/REISE.jl:84',

```

### What the code is doing
First I tried changing the signature back to a comma, but the formatter doesn't like that.  So instead we can update usages to keyword arguments.

### Testing
Launched a scenario in a container.

### Time estimate
2 min
