### PR TITLE
feat: support for mixed flexibility input granularity (#157)

### DIFF
--- a/src/REISE.jl
+++ b/src/REISE.jl
@@ -6,7 +6,8 @@ using Dates: Dates
 using JuMP: JuMP
 using MAT: MAT
 using Requires: Requires
-import SparseArrays: sparse, SparseMatrixCSC
+
+import SparseArrays: sparse, SparseMatrixCSC, findnz, nnz
 
 include("types.jl")         # Defines Case, Results, Storage, DemandFlexibility,
 #     VariablesOfInterest
@@ -68,6 +69,8 @@ function run_scenario(;
     demand_flexibility = read_demand_flexibility(inputfolder, interval)
     println("All scenario files loaded!")
     case = reise_data_mods(case; num_segments=num_segments)
+    sets = _make_sets(case)
+    demand_flexibility = reformat_demand_flexibility_input(case, demand_flexibility, sets)
     save_input_mat(case, storage, inputfolder, outputfolder)
     # Create final model kwargs by merging defaults with user-specified
     default_model_kwargs = Dict(

--- a/src/model.jl
+++ b/src/model.jl
@@ -70,10 +70,11 @@ function _make_bus_demand_flexibility_amount(
     simulation_demand_flex_amt_dn = Matrix(
         demand_flexibility.flex_amt_dn[start_index:end_index, 2:end]
     )
-    # input is already per-bus, copy to new container
-    bus_demand_flex_amt_up = permutedims(simulation_demand_flex_amt_up)
-    bus_demand_flex_amt_dn = permutedims(simulation_demand_flex_amt_dn)
-    return (bus_demand_flex_amt_up, bus_demand_flex_amt_dn)
+
+    return (
+        permutedims(simulation_demand_flex_amt_up),
+        permutedims(simulation_demand_flex_amt_dn),
+    )
 end
 
 """

--- a/src/model.jl
+++ b/src/model.jl
@@ -37,28 +37,6 @@ function _make_branch_map(case::Case)::SparseMatrixCSC
 end
 
 """
-    _make_bus_demand_weighting(case)
-
-Given a Case object, build a sparse matrix that indicates the weighting of each bus in 
-    each zone.
-"""
-function _make_bus_demand_weighting(case::Case)::SparseMatrixCSC
-    bus_idx = 1:length(case.busid)
-    bus_df = DataFrames.DataFrame(;
-        name=case.busid, load=case.bus_demand, zone=case.bus_zone
-    )
-    zone_demand = DataFrames.combine(DataFrames.groupby(bus_df, :zone), :load => sum)
-    zone_list = sort(collect(Set(case.bus_zone)))
-    zone_idx = 1:length(zone_list)
-    zone_id2idx = Dict(zone_list .=> zone_idx)
-    bus_df_with_zone_load = DataFrames.innerjoin(bus_df, zone_demand; on=:zone)
-    bus_share = bus_df[:, :load] ./ bus_df_with_zone_load[:, :load_sum]
-    bus_zone_idx = Int64[zone_id2idx[z] for z in case.bus_zone]
-    zone_to_bus_shares = sparse(bus_zone_idx, bus_idx, bus_share)::SparseMatrixCSC
-    return zone_to_bus_shares
-end
-
-"""
     _make_bus_demand(case)
 
 Given a Case object, build a matrix of demand by (bus, hour) for this interval.
@@ -92,21 +70,9 @@ function _make_bus_demand_flexibility_amount(
     simulation_demand_flex_amt_dn = Matrix(
         demand_flexibility.flex_amt_dn[start_index:end_index, 2:end]
     )
-    # convert per-area input to per-bus values
-    if demand_flexibility.input_granularity == "AREA"
-        bus_demand_flex_amt_up = permutedims(
-            simulation_demand_flex_amt_up * zone_to_bus_shares
-        )
-        bus_demand_flex_amt_dn = permutedims(
-            simulation_demand_flex_amt_dn * zone_to_bus_shares
-        )
-        # input is already per-bus, copy to new container
-    elseif demand_flexibility.input_granularity == "BUS"
-        bus_demand_flex_amt_up = permutedims(simulation_demand_flex_amt_up)
-        bus_demand_flex_amt_dn = permutedims(simulation_demand_flex_amt_dn)
-    else
-        println("Warning! Invalid demand flexibility parameter input_granularity!")
-    end
+    # input is already per-bus, copy to new container
+    bus_demand_flex_amt_up = permutedims(simulation_demand_flex_amt_up)
+    bus_demand_flex_amt_dn = permutedims(simulation_demand_flex_amt_dn)
     return (bus_demand_flex_amt_up, bus_demand_flex_amt_dn)
 end
 
@@ -179,22 +145,18 @@ function _make_sets(
     )
     num_segments = convert(Int, maximum(case.gencost[:, NCOST])) - 1
     segment_idx = 1:num_segments
-    # Demand flexibility, additional info for input->bus conversion
-    if demand_flexibility.enabled
-        if demand_flexibility.input_granularity == "BUS"
-            # assume each flexible bus can go up/dn, so only use the Dataframe for up
-            flexible_bus_str = names(demand_flexibility.flex_amt_up)[2:end]
-            flexible_bus_id = [parse(Int64, bus) for bus in flexible_bus_str]
-            flexible_bus_idx = [bus_id2idx[bus] for bus in flexible_bus_id]
-            num_flexible_bus = length(flexible_bus_idx)
-            flexible_load_bus_map = sparse(
-                flexible_bus_idx, 1:num_flexible_bus, 1, num_bus, num_flexible_bus
-            )::SparseMatrixCSC
-        elseif demand_flexibility.input_granularity == "AREA"
-            flexible_bus_idx = load_bus_idx
-            num_flexible_bus = num_load_bus
-            flexible_load_bus_map = load_bus_map
-        end
+    # Demand flexibility, additional info for bus <--> load <--> flexible load conversion
+    demand_flexibility_enabled =
+        isa(demand_flexibility, DemandFlexibility) && demand_flexibility.enabled
+    if demand_flexibility_enabled
+        # assume each flexible bus can go up/dn, so only use the Dataframe for up
+        flexible_bus_str = names(demand_flexibility.flex_amt_up)[2:end]
+        flexible_bus_id = [parse(Int64, bus) for bus in flexible_bus_str]
+        flexible_bus_idx = [bus_id2idx[bus] for bus in flexible_bus_id]
+        num_flexible_bus = length(flexible_bus_idx)
+        flexible_load_bus_map = sparse(
+            flexible_bus_idx, 1:num_flexible_bus, 1, num_bus, num_flexible_bus
+        )::SparseMatrixCSC
     else
         flexible_bus_idx = nothing
         num_flexible_bus = 0
@@ -379,7 +341,7 @@ function _add_constraints_demand_flexibility!(
         println("rolling load balance, first window: ", Dates.now())
         JuMP.@constraint(
             m,
-            rolling_load_balance_first[i in 1:(sets.num_load_bus)],
+            rolling_load_balance_first[i in 1:(sets.num_flexible_bus)],
             sum(
                 m[:load_shift_up][i, j] - m[:load_shift_dn][i, j] for
                 j in 1:(demand_flexibility.duration - 1)

--- a/src/read.jl
+++ b/src/read.jl
@@ -298,7 +298,7 @@ function reformat_demand_flexibility_input(
             ErrorException(
                 "The flexible bus/load zone specified in the up/down " *
                 "input csvs do not match. Please check the input files to make sure " *
-                "every flexible bus orload zone has corresponding columns in both " *
+                "every flexible bus or load zone has corresponding columns in both " *
                 "flexibility csvs.",
             ),
         )

--- a/src/read.jl
+++ b/src/read.jl
@@ -114,7 +114,6 @@ function read_demand_flexibility(filepath, interval)::DemandFlexibility
         "enabled" => "not_specified",
         "interval_balance" => true,
         "rolling_balance" => true,
-        "input_granularity" => "AREA",
     )
 
     # Try loading the demand flexibility parameters
@@ -143,11 +142,6 @@ function read_demand_flexibility(filepath, interval)::DemandFlexibility
             "rolling_balance" => (
                 "The parameter that indicates if the rolling load balance constraint " *
                 "is enabled is not defined. Will default to being enabled."
-            ),
-            "input_granularity" => (
-                "The parameter that indicates the way demand flexibility " *
-                "and demand flexibility cost are provided is not defined. " *
-                "Will default to being area-based."
             ),
         )
 
@@ -260,4 +254,182 @@ function read_demand_flexibility(filepath, interval)::DemandFlexibility
     demand_flexibility = DemandFlexibility(; demand_flexibility...)
 
     return demand_flexibility
+end
+
+"""
+    _make_bus_demand_weighting(case)
+
+Given a Case object, build a sparse matrix that indicates the weighting of each bus in 
+    each zone.
+"""
+function _make_bus_demand_weighting(case::Case)::SparseMatrixCSC
+    bus_idx = 1:length(case.busid)
+    bus_df = DataFrames.DataFrame(;
+        name=case.busid, load=case.bus_demand, zone=case.bus_zone
+    )
+    zone_demand = DataFrames.combine(DataFrames.groupby(bus_df, :zone), :load => sum)
+    zone_list = sort(collect(Set(case.bus_zone)))
+    zone_idx = 1:length(zone_list)
+    zone_id2idx = Dict(zone_list .=> zone_idx)
+    bus_df_with_zone_load = DataFrames.innerjoin(bus_df, zone_demand; on=:zone)
+    bus_share = bus_df[:, :load] ./ bus_df_with_zone_load[:, :load_sum]
+    bus_zone_idx = Int64[zone_id2idx[z] for z in case.bus_zone]
+    zone_to_bus_shares = sparse(bus_zone_idx, bus_idx, bus_share)::SparseMatrixCSC
+    return zone_to_bus_shares
+end
+
+"""
+    reformat_demand_flexibility_input(case, demand_flexibility, sets)
+
+Inspect the raw input files of flexiblility amount and cost, convert the zone/bus mixed 
+    data to bus data
+"""
+function reformat_demand_flexibility_input(
+    case::Case, demand_flexibility::DemandFlexibility, sets::Sets
+)
+    # list of zones in the network
+    zone_list = sort(collect(Set(case.bus_zone)))
+    # distribute zone-level aggregated number to buses
+    zone_to_bus_shares = _make_bus_demand_weighting(case)
+    # incidence matrix of mapping between zone and bus
+    zone_to_bus_incidence = deepcopy(zone_to_bus_shares)
+    (x, y, v) = findnz(zone_to_bus_incidence)
+    for i in 1:nnz(zone_to_bus_incidence)
+        # buses with no load still show up as nonzero entries
+        if v[i] > 0
+            zone_to_bus_incidence[x[i], y[i]] = 1
+        end
+    end
+
+    # create an empty demand flexibility object and copy unchanged fields
+    demand_flexibility_updated = Dict(
+        "duration" => demand_flexibility.duration,
+        "enabled" => demand_flexibility.enabled,
+        "interval_balance" => demand_flexibility.interval_balance,
+        "rolling_balance" => demand_flexibility.rolling_balance,
+        "flex_amt_up" => nothing,
+        "flex_amt_dn" => nothing,
+        "cost_up" => nothing,
+        "cost_dn" => nothing,
+    )
+
+    # iterate through fields
+    for field in ["flex_amt_up", "flex_amt_dn", "cost_up", "cost_dn"]
+        # dataframe in the corresponding field
+        fh = getfield(demand_flexibility, Symbol(field))
+
+        # headers
+        flexible_str = names(fh)[2:end]
+
+        # index of columns specifing the flexibility of a zone
+        zone_columns_idx = findall(x -> occursin("zone.", x), flexible_str)
+
+        # numeric ID corresponding to zone columns
+        flexible_zone_id = [
+            parse(Int64, replace(flexible_str[i], "zone." => "")) for i in zone_columns_idx
+        ]
+        flexible_zone_num = length(flexible_zone_id)
+
+        # index of columns specifing the flexibility of a bus
+        bus_columns_idx = findall(x -> !occursin(".", x), flexible_str)
+
+        # numeric ID corresponding to bus columns
+        flexible_bus_id = [parse(Int64, flexible_str[i]) for i in bus_columns_idx]
+        flexible_bus_num = length(flexible_bus_id)
+
+        # check if zone numbers are correct
+        if !all([issubset(i, zone_list) for i in flexible_zone_id])
+            @error("Invalid load zone numeric ID(s) in demand flexibility input files!")
+        elseif !all([issubset(i, case.busid) for i in flexible_bus_id])
+            @error("Invalid load bus numeric ID(s) in demand flexibility input files!")
+        end
+
+        # list index of each zone in input file in the sorted list of zones
+        zone_cols_idx = findall(x -> x in flexible_zone_id, zone_list)
+
+        # for flex amt, the zone numbers are the total flexibility in the zone
+        if field == "flex_amt_up" || field == "flex_amt_dn"
+            # find if the flexibility of any bus is also specified in a zone column
+            bus_cols_zone_id = case.bus_zone[findall(x -> x in flexible_bus_id, case.busid)]
+            bus_cols_zone_idx = [
+                findfirst(isequal(i), flexible_zone_id) for i in bus_cols_zone_id
+            ]
+
+            # substract individual bus columns from zone total flexibility
+            for i in 1:flexible_bus_num
+                # substract from total if the zone of this bus is specified in a zone column
+                if !isnothing(bus_cols_zone_idx[i])
+                    fh[:, zone_columns_idx[bus_cols_zone_idx[i]] + 1] -= fh[
+                        :, bus_columns_idx[i] + 1
+                    ]
+                end
+            end
+
+            # check if flexibility in any zone is less than the sum of buses
+            for i in 1:flexible_zone_num
+                if any(x -> x < 0, fh[:, zone_columns_idx[flexible_zone_num] + 1])
+                    @error(
+                        "Input ERROR: Total zone flexibility less than sum of bus flexibility for zone " *
+                            string(flexible_zone_id[i])
+                    )
+                end
+            end
+
+            # convert zone-level to bus-level
+            converted_zone_flexibility =
+                Matrix(fh[:, [i + 1 for i in zone_columns_idx]]) * zone_to_bus_shares[zone_cols_idx, :]
+
+            # add bus-level columns on top of converted bus-level flexibility matrix
+            flex_bus_idx = zeros(Int64, 0)
+            for i in sets.bus_idx
+                bus = case.busid[i]
+                # add specified flexibility to the corresponding bus
+                if bus in flexible_bus_id
+                    converted_zone_flexibility[:, i] += fh[string(bus)]
+                end
+
+                # identify flexible bus by their total flexibility and append to list
+                if any(x -> x > 0, converted_zone_flexibility[:, i])
+                    append!(flex_bus_idx, i)
+                end
+            end
+            # for cost, the zone numbers apply to all buses except those with dedicated columns
+        else
+            # convert zone-level cost using incidence matrix
+            converted_zone_flexibility =
+                Matrix(fh[:, [i + 1 for i in zone_columns_idx]]) * zone_to_bus_incidence[zone_cols_idx, :]
+
+            # replace bus-level cost for bus columns in converted bus-level cost matrix
+            flex_bus_idx = zeros(Int64, 0)
+            for i in sets.bus_idx
+                bus = case.busid[i]
+                # add specified flexibility to the corresponding bus
+                if bus in flexible_bus_id
+                    converted_zone_flexibility[:, i] = fh[string(bus)]
+                end
+
+                # identify flexible bus by their total flexibility and append to list
+                if any(x -> x > 0, converted_zone_flexibility[:, i])
+                    append!(flex_bus_idx, i)
+                end
+            end
+        end
+
+        # add header and datetime index column
+        eq_bus_df = DataFrames.DataFrame(converted_zone_flexibility[:, flex_bus_idx])
+        DataFrames.rename!(eq_bus_df, Symbol.(case.busid[flex_bus_idx]))
+        DataFrames.insertcols!(eq_bus_df, 1, :"UTC Time" => fh["UTC Time"])
+
+        # replace the raw input df
+        #setfield!(demand_flexibility_updated, Symbol(field), eq_bus_df)
+        demand_flexibility_updated[field] = eq_bus_df
+    end
+
+    # Convert Dict to type DemandFlexibility
+    demand_flexibility_updated = (;
+        (Symbol(k) => v for (k, v) in demand_flexibility_updated)...
+    )
+    demand_flexibility_updated = DemandFlexibility(; demand_flexibility_updated...)
+
+    return demand_flexibility_updated
 end

--- a/src/read.jl
+++ b/src/read.jl
@@ -293,11 +293,9 @@ function reformat_demand_flexibility_input(
         sort(names(demand_flexibility.flex_amt_up)) .==
         sort(names(demand_flexibility.flex_amt_dn)),
     )
-        @error(
-            "The flexible bus/load zone specified in the up/down input csvs do not 
-            match. Please check the input files to make sure every flexible bus or
-            load zone has corresponding columns in both flexibility csvs."
-        )
+        @error("The flexible bus/load zone specified in the up/down input csvs do not 
+               match. Please check the input files to make sure every flexible bus or
+               load zone has corresponding columns in both flexibility csvs.")
         throw(ErrorException("See above."))
     end
 
@@ -371,18 +369,10 @@ function reformat_demand_flexibility_input(
             # check if zone numbers are correct
             if !all([issubset(i, zone_list) for i in flexible_zone_id])
                 @error("Invalid load zone numeric ID(s) in demand flexibility input files!")
-                throw(
-                    ErrorException(
-                        "See above."
-                    ),
-                )
+                throw(ErrorException("See above."))
             elseif !all([issubset(i, case.busid) for i in flexible_bus_id])
                 @error("Invalid load bus numeric ID(s) in demand flexibility input files!")
-                throw(
-                    ErrorException(
-                        "See above."
-                    ),
-                )
+                throw(ErrorException("See above."))
             end
 
             # list index of each zone in input file in the sorted list of zones
@@ -415,7 +405,7 @@ function reformat_demand_flexibility_input(
                         if any(x -> x < 0, fh[:, zone_columns_idx[flexible_zone_num] + 1])
                             @error(
                                 "Input ERROR: Total zone flexibility less than sum of bus flexibility for zone " *
-                                string(flexible_zone_id[i])
+                                    string(flexible_zone_id[i])
                             )
                             throw(ErrorException("See above."))
                         end

--- a/src/read.jl
+++ b/src/read.jl
@@ -293,7 +293,12 @@ function reformat_demand_flexibility_input(
         sort(names(demand_flexibility.flex_amt_up)) .==
         sort(names(demand_flexibility.flex_amt_dn)),
     )
-        throw(ErrorException("Mismatch in columns of demand flexibility input files"))
+        @error(
+            "The flexible bus/load zone specified in the up/down input csvs do not 
+            match. Please check the input files to make sure every flexible bus or
+            load zone has corresponding columns in both flexibility csvs."
+        )
+        throw(ErrorException("See above."))
     end
 
     # list of zones in the network
@@ -365,15 +370,17 @@ function reformat_demand_flexibility_input(
 
             # check if zone numbers are correct
             if !all([issubset(i, zone_list) for i in flexible_zone_id])
+                @error("Invalid load zone numeric ID(s) in demand flexibility input files!")
                 throw(
                     ErrorException(
-                        "Invalid load zone numeric ID(s) in demand flexibility input files!"
+                        "See above."
                     ),
                 )
             elseif !all([issubset(i, case.busid) for i in flexible_bus_id])
+                @error("Invalid load bus numeric ID(s) in demand flexibility input files!")
                 throw(
                     ErrorException(
-                        "Invalid load bus numeric ID(s) in demand flexibility input files!"
+                        "See above."
                     ),
                 )
             end
@@ -406,12 +413,11 @@ function reformat_demand_flexibility_input(
                     # check if flexibility in any zone is less than the sum of buses
                     for i in 1:flexible_zone_num
                         if any(x -> x < 0, fh[:, zone_columns_idx[flexible_zone_num] + 1])
-                            throw(
-                                ErrorException(
-                                    "Input ERROR: Total zone flexibility less than sum of bus flexibility for zone " *
-                                    string(flexible_zone_id[i]),
-                                ),
+                            @error(
+                                "Input ERROR: Total zone flexibility less than sum of bus flexibility for zone " *
+                                string(flexible_zone_id[i])
                             )
+                            throw(ErrorException("See above."))
                         end
                     end
                 end

--- a/src/read.jl
+++ b/src/read.jl
@@ -218,13 +218,14 @@ function read_demand_flexibility(filepath, interval)::DemandFlexibility
         isnothing(demand_flexibility["flex_amt_up"]) ||
         (isnothing(demand_flexibility["flex_amt_dn"]))
     )
-        @error(
-            "Demand flexibility was specified to be enabled, however at least one " *
-                "demand flexibility profile is missing. Please make sure both demand " *
-                "flexibility profiles are included in " *
-                filepath
+        throw(
+            ErrorException(
+                "Demand flexibility was specified to be enabled, however at " *
+                "least one demand flexibility profile is missing. Please make sure both " *
+                "demand flexibility profiles are included in " *
+                filepath,
+            ),
         )
-        throw(ErrorException("See above."))
     elseif demand_flexibility["enabled"] == "not_specified"
         if !isnothing(demand_flexibility["flex_amt_up"]) &&
             (!isnothing(demand_flexibility["flex_amt_dn"]))
@@ -293,10 +294,14 @@ function reformat_demand_flexibility_input(
         sort(names(demand_flexibility.flex_amt_up)) .==
         sort(names(demand_flexibility.flex_amt_dn)),
     )
-        @error("The flexible bus/load zone specified in the up/down input csvs do not 
-               match. Please check the input files to make sure every flexible bus or
-               load zone has corresponding columns in both flexibility csvs.")
-        throw(ErrorException("See above."))
+        throw(
+            ErrorException(
+                "The flexible bus/load zone specified in the up/down " *
+                "input csvs do not match. Please check the input files to make sure " *
+                "every flexible bus orload zone has corresponding columns in both " *
+                "flexibility csvs.",
+            ),
+        )
     end
 
     # list of zones in the network
@@ -368,11 +373,17 @@ function reformat_demand_flexibility_input(
 
             # check if zone numbers are correct
             if !all([issubset(i, zone_list) for i in flexible_zone_id])
-                @error("Invalid load zone numeric ID(s) in demand flexibility input files!")
-                throw(ErrorException("See above."))
+                throw(
+                    ErrorException(
+                        "Invalid load zone numeric ID(s) in demand flexibility input files!"
+                    ),
+                )
             elseif !all([issubset(i, case.busid) for i in flexible_bus_id])
-                @error("Invalid load bus numeric ID(s) in demand flexibility input files!")
-                throw(ErrorException("See above."))
+                throw(
+                    ErrorException(
+                        "Invalid load bus numeric ID(s) in demand flexibility input files!"
+                    ),
+                )
             end
 
             # list index of each zone in input file in the sorted list of zones
@@ -403,11 +414,12 @@ function reformat_demand_flexibility_input(
                     # check if flexibility in any zone is less than the sum of buses
                     for i in 1:flexible_zone_num
                         if any(x -> x < 0, fh[:, zone_columns_idx[flexible_zone_num] + 1])
-                            @error(
-                                "Input ERROR: Total zone flexibility less than sum of bus flexibility for zone " *
-                                    string(flexible_zone_id[i])
+                            throw(
+                                ErrorException(
+                                    "Input ERROR: Total zone flexibility less than sum of bus
+                       flexibility for zone " * string(flexible_zone_id[i]),
+                                ),
                             )
-                            throw(ErrorException("See above."))
                         end
                     end
                 end

--- a/src/solver_specific/gurobi.jl
+++ b/src/solver_specific/gurobi.jl
@@ -13,8 +13,8 @@ function run_scenario_gurobi(; solver_kwargs::Union{Dict,Nothing}=nothing, kwarg
         global m = run_scenario(;
             optimizer_factory=env, solver_kwargs=solver_kwargs, kwargs...
         )
-    finally
         Gurobi.finalize(JuMP.backend(m))
+    finally
         Gurobi.finalize(env)
         println("Connection to Gurobi closed successfully!")
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -50,7 +50,6 @@ Base.@kwdef struct DemandFlexibility
     enabled::Bool
     interval_balance::Bool
     rolling_balance::Bool
-    input_granularity::String
 end
 
 Base.@kwdef struct Results


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Implement changed proposed in #157 

### What the code is doing
inspect the raw input dataframe for demand flexibility and its cost, convert zone-level flexibility to bus-level and concatenate with the bus-level flexibility input columns 

### Where to look
the core code is added to bottom read.jl

### Time estimate
15-30 min
