### PR TITLE
feat: enable (penalized) transmission line constraint violations

### DIFF
--- a/pyreisejl/utility/extract_data.py
+++ b/pyreisejl/utility/extract_data.py
@@ -68,6 +68,15 @@ def extract_data(results):
     sparse_extraction_vars = {"congu", "congl", "load_shed", "trans_viol"}
     temps = {}
     outputs = {}
+    optional_variables = [
+        {"name": "pf_dcline", "key1": "dcline", "key2": "PF_dcline"},
+        {"name": "storage_pg", "key1": "storage", "key2": "PG"},
+        {"name": "storage_e", "key1": "storage", "key2": "Energy"},
+        {"name": "load_shed", "key1": "load_shed", "key2": "load_shed"},
+        {"name": "load_shift_up", "key1": "flexible_demand", "key2": "load_shift_up"},
+        {"name": "load_shift_dn", "key1": "flexible_demand", "key2": "load_shift_dn"},
+        {"name": "trans_viol", "key1": "trans_viol", "key2": "trans_viol"},
+    ]
 
     tic = time.process_time()
     for i, filename in tqdm(enumerate(results)):
@@ -96,34 +105,12 @@ def extract_data(results):
         temps["congl"] = output_mpc["branch"]["MU_ST"].T
 
         # Extract optional variables (not present in all scenarios)
-        try:
-            temps["pf_dcline"] = output_mpc["dcline"]["PF_dcline"].T
-            extraction_vars |= {"pf_dcline"}
-        except KeyError:
-            pass
-
-        try:
-            temps["storage_pg"] = output_mpc["storage"]["PG"].T
-            temps["storage_e"] = output_mpc["storage"]["Energy"].T
-            extraction_vars |= {"storage_pg", "storage_e"}
-        except KeyError:
-            pass
-        try:
-            temps["load_shed"] = output_mpc["load_shed"]["load_shed"].T
-            extraction_vars |= {"load_shed"}
-        except KeyError:
-            pass
-        try:
-            temps["load_shift_up"] = output_mpc["flexible_demand"]["load_shift_up"].T
-            temps["load_shift_dn"] = output_mpc["flexible_demand"]["load_shift_dn"].T
-            extraction_vars |= {"load_shift_up", "load_shift_dn"}
-        except KeyError:
-            pass
-        try:
-            temps["trans_viol"] = output_mpc["trans_viol"]["trans_viol"].T
-            extraction_vars |= {"trans_viol"}
-        except KeyError:
-            pass
+        for var in optional_variables:
+            try:
+                temps[var["name"]] = output_mpc[var["key1"]][var["key2"]].T
+                extraction_vars.add(var["name"])
+            except KeyError:
+                pass
 
         # Extract which number result currently being processed
         i = result_num(filename)

--- a/pyreisejl/utility/extract_data.py
+++ b/pyreisejl/utility/extract_data.py
@@ -65,7 +65,7 @@ def extract_data(results):
     cost = []
 
     extraction_vars = {"pf", "pg", "lmp", "congu", "congl"}
-    sparse_extraction_vars = {"congu", "congl", "load_shed"}
+    sparse_extraction_vars = {"congu", "congl", "load_shed", "trans_viol"}
     temps = {}
     outputs = {}
 
@@ -117,6 +117,11 @@ def extract_data(results):
             temps["load_shift_up"] = output_mpc["flexible_demand"]["load_shift_up"].T
             temps["load_shift_dn"] = output_mpc["flexible_demand"]["load_shift_dn"].T
             extraction_vars |= {"load_shift_up", "load_shift_dn"}
+        except KeyError:
+            pass
+        try:
+            temps["trans_viol"] = output_mpc["trans_viol"]["trans_viol"].T
+            extraction_vars |= {"trans_viol"}
         except KeyError:
             pass
 
@@ -246,10 +251,11 @@ def _get_outputs_from_converted(matfile):
     }
 
     try:
+        # If DC lines are present in the input file, use their indices
         outputs_id["pf_dcline"] = case.mpc.dclineid
+        outputs_id["trans_viol"] = list(case.mpc.branchid) + list(case.mpc.dclineid)
     except AttributeError:
-        pass
-
+        outputs_id["trans_viol"] = case.mpc.branchid
     try:
         storage_index = case.Storage.UnitIdx
         num_storage = 1 if isinstance(storage_index, float) else len(storage_index)

--- a/src/REISE.jl
+++ b/src/REISE.jl
@@ -51,6 +51,7 @@ function run_scenario(;
     threads::Union{Int,Nothing}=nothing,
     optimizer_factory=nothing,
     solver_kwargs::Union{Dict,Nothing}=nothing,
+    model_kwargs::Union{Dict,Nothing}=nothing,
 )
     isnothing(optimizer_factory) && error("optimizer_factory must be specified")
     # Setup things that build once
@@ -68,12 +69,18 @@ function run_scenario(;
     println("All scenario files loaded!")
     case = reise_data_mods(case; num_segments=num_segments)
     save_input_mat(case, storage, inputfolder, outputfolder)
-    model_kwargs = Dict(
+    # Create final model kwargs by merging defaults with user-specified
+    default_model_kwargs = Dict(
         "case" => case,
         "storage" => storage,
         "demand_flexibility" => demand_flexibility,
         "interval_length" => interval,
     )
+    if isnothing(model_kwargs)
+        model_kwargs = default_model_kwargs
+    else
+        model_kwargs = merge(default_model_kwargs, model_kwargs)
+    end
     # If a number of threads is specified, add to solver settings dict
     isnothing(threads) || (solver_kwargs["Threads"] = threads)
     println("All preparation complete!")

--- a/src/model.jl
+++ b/src/model.jl
@@ -541,6 +541,7 @@ function _add_objective_function!(
     load_shed_enabled::Bool,
     load_shed_penalty::Number,
     trans_viol_enabled::Bool,
+    trans_viol_penalty::Number,
     storage_e0::Array{Float64,1},
     demand_flexibility::DemandFlexibility,
 )
@@ -773,6 +774,7 @@ function _build_model(
         load_shed_enabled,
         load_shed_penalty,
         trans_viol_enabled,
+        trans_viol_penalty,
         storage_e0,
         demand_flexibility,
     )

--- a/src/model.jl
+++ b/src/model.jl
@@ -470,15 +470,11 @@ function _add_constraints_branch_flow_limits!(
     branch_pmin = vcat(-1 * case.branch_rating, case.dcline_pmin)
     branch_pmax = vcat(case.branch_rating, case.dcline_pmax)
     if trans_viol_enabled
-        JuMP.@expression(m, branch_limit_pmin, branch_pmin - m[:trans_viol])
-        JuMP.@expression(m, branch_limit_pmax, branch_pmax + m[:trans_viol])
+        JuMP.@expression(m, branch_limit_pmin, branch_pmin .- m[:trans_viol])
+        JuMP.@expression(m, branch_limit_pmax, branch_pmax .+ m[:trans_viol])
     else
-        JuMP.@expression(
-            m, branch_limit_pmin[br in sets.branch_idx, h in hour_idx], branch_pmin[br],
-        )
-        JuMP.@expression(
-            m, branch_limit_pmax[br in sets.branch_idx, h in hour_idx], branch_pmax[br],
-        )
+        JuMP.@expression(m, branch_limit_pmin, repeat(branch_pmin, 1, length(hour_idx)))
+        JuMP.@expression(m, branch_limit_pmax, repeat(branch_pmax, 1, length(hour_idx)))
     end
     println("branch_min, branch_max: ", Dates.now())
     JuMP.@constraint(

--- a/src/query.jl
+++ b/src/query.jl
@@ -80,6 +80,18 @@ function get_results(f::Float64, case::Case, demand_flexibility::DemandFlexibili
         end
     end
 
+    trans_viol = zeros(0, 0)
+    try
+        trans_viol = JuMP.value.(m[:trans_viol])
+    catch e
+        if isa(e, MethodError)
+            # Thrown when trans_viol is `nothing`
+        else
+            # Unknown error, rethrow it
+            rethrow(e)
+        end
+    end
+
     results = Results(;
         pg=pg,
         pf=pf,
@@ -94,6 +106,7 @@ function get_results(f::Float64, case::Case, demand_flexibility::DemandFlexibili
         load_shift_up=load_shift_up,
         load_shift_dn=load_shift_dn,
         status=status,
+        trans_viol=trans_viol,
     )
     return results
 end

--- a/src/save.jl
+++ b/src/save.jl
@@ -99,6 +99,9 @@ function save_results(results::Results, filename::String; demand_scaling::Number
             "load_shift_dn" => results.load_shift_dn,
         )
     end
+    if size(results.trans_viol) != (0, 0)
+        mdo_save["flow"]["mpc"]["trans_viol"] = Dict("trans_viol" => results.trans_viol)
+    end
     return MAT.matwrite(filename, Dict("mdo_save" => mdo_save); compress=true)
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -66,6 +66,7 @@ Base.@kwdef struct Results
     load_shed::Array{Float64,2}
     load_shift_up::Array{Float64,2}
     load_shift_dn::Array{Float64,2}
+    trans_viol::Array{Float64,2}
     f::Float64
     status::String
 end


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Add a way for users to enable (penalized) transmission line flow violations from the Julia interface, and to analyze them after the result files are extracted. Closes #128.

### What the code is doing
- In **model.jl**: fixing mistakes the prevented transmission violation slack variables from working properly when we pass `trans_viol_enable=true` to `_build_model`, and simplifying the construction of the JuMP expression for branch flow limits when `trans_viol_enable=false` (default).
- In **types.jl**, **query.jl**, and **save.jl**: adding `trans_viol` to the list of variables that will be extracted from the JuMP problem solution and saved to .mat files.
- In **REISE.jl**: adding a new `model_kwargs` input parameter to allow the user to pass model keyword arguments, overriding default settings as applicable.
- In **extract_data.py**: adding `trans_viol` to the list of variables that will be extracted from the collection of .mat files and saved as pickled dataframes, and refactoring the extraction of optimal variables for brevity.

### Testing
Tested manually, by running a scenario with load shedding and transmission violations enabled by default:
```julia
import Gurobi
import REISE
REISE.run_scenario_gurobi(;
    interval=24,
    n_interval=366,
    start_index=1,
    inputfolder=".",
    model_kwargs = Dict(
        "load_shed_enabled" => true,
        "trans_viol_enabled" => true,
        "trans_viol_penalty" => 10000,
    )
)
```

This scenario was known to be infeasible from the start due to minimum generation limit constraints that were incompatible with the local transmission network. Note: this was an ERCOT grid with no DC lines, so this hasn't been tested with mixed AC & DC networks yet.

Then extracting the outputs in the standard way using the `pyreisejl` command-line interface:
```
python path/to/REISE.jl/pyreisejl/utility/extract_data.py -s 2016-01-01 -e 2016-12-31 -x "path/to/outputs" -k
```

As expected, there's a new file **TRANS_VIOL.pkl** created next to **PG.pkl**, **PF.pkl**, etc.

### Time estimate
30 minutes. The largest changes are fairly straightforward refactors, the rest are smaller bug-fixes or tweaked copies of code elsewhere.
