### PR TITLE
fix: make trans_viol extraction index a numpy array

### DIFF
--- a/pyreisejl/utility/extract_data.py
+++ b/pyreisejl/utility/extract_data.py
@@ -240,7 +240,9 @@ def _get_outputs_from_converted(matfile):
     try:
         # If DC lines are present in the input file, use their indices
         outputs_id["pf_dcline"] = case.mpc.dclineid
-        outputs_id["trans_viol"] = list(case.mpc.branchid) + list(case.mpc.dclineid)
+        outputs_id["trans_viol"] = np.concatenate(
+            [case.mpc.branchid, case.mpc.dclineid]
+        )
     except AttributeError:
         outputs_id["trans_viol"] = case.mpc.branchid
     try:


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Correct a bug from #163: when DC lines are present, there will be an AttributeError when we try to call `.tolist()` on a list, rather than a numpy array.

### What the code is doing
Instead of converting the two arrays to lists and adding them together, concatenate them into a numpy array.

### Testing
Tested manually on outputs from the Western interconnect: failed at first, now works.

### Time estimate
5 minutes.
