### PR TITLE
fix: add KeyError to trans_viol try-catch block

### DIFF
--- a/src/query.jl
+++ b/src/query.jl
@@ -86,6 +86,8 @@ function get_results(f::Float64, case::Case, demand_flexibility::DemandFlexibili
     catch e
         if isa(e, MethodError)
             # Thrown when trans_viol is `nothing`
+        elseif isa(e, KeyError)
+            # Thrown when trans_viol is not defined in the model
         else
             # Unknown error, rethrow it
             rethrow(e)


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Fix a bug that causes an error to be thrown when the `:trans_viol` key is not defined in the model (i.e., `trans_viol` is not enabled).

### What the code is doing
I add `KeyError` to the `try`-`catch` block associated with `trans_viol` in the `get_results` function.

### Testing
I tested locally on a test case that isn't known to create transmission violations and it now completes the simulation without throwing an error. The inclusion of `KeyError` in the `try`-`catch` block also seems to follow a similar procedure that was followed for other variables that aren't necessarily always enabled (e.g., variables related to storage and flexible demand).

### Where to look
This fix is in the `get_results` function of `query.jl`.

### Time estimate
Should be quick. Probably only a couple minutes
