### PR TITLE
fix: avoid error when demand flexibility isn't enabled

### DIFF
--- a/src/REISE.jl
+++ b/src/REISE.jl
@@ -70,7 +70,11 @@ function run_scenario(;
     println("All scenario files loaded!")
     case = reise_data_mods(case; num_segments=num_segments)
     sets = _make_sets(case)
-    demand_flexibility = reformat_demand_flexibility_input(case, demand_flexibility, sets)
+    if demand_flexibility.enabled
+        demand_flexibility = reformat_demand_flexibility_input(
+            case, demand_flexibility, sets
+        )
+    end
     save_input_mat(case, storage, inputfolder, outputfolder)
     # Create final model kwargs by merging defaults with user-specified
     default_model_kwargs = Dict(

--- a/src/read.jl
+++ b/src/read.jl
@@ -290,7 +290,8 @@ function reformat_demand_flexibility_input(
 )
 
     # check consistency of flexibility input headers
-    if !all(
+    if demand_flexibility.enabled &&
+        !all(
         sort(names(demand_flexibility.flex_amt_up)) .==
         sort(names(demand_flexibility.flex_amt_dn)),
     )

--- a/src/read.jl
+++ b/src/read.jl
@@ -290,8 +290,7 @@ function reformat_demand_flexibility_input(
 )
 
     # check consistency of flexibility input headers
-    if demand_flexibility.enabled &&
-        !all(
+    if !all(
         sort(names(demand_flexibility.flex_amt_up)) .==
         sort(names(demand_flexibility.flex_amt_dn)),
     )


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Fix a bug which causes an exception when demand flexibility isn't enabled. If it's not, then the `demand_flexibility.flex_amt_up` and `demand_flexibility.flex_amt_dn` attributes are `nothing`, and calling `names(nothing)` results in an exception.

### What the code is doing
Before calling `names` on something that may be `nothing`, we check whether demand flexibility is enabled or not. If it's not enabled, then the second condition within the `if` condition will never be evaluated, so the error will be avoided.

### Testing
Tested manually.

### Time estimate
5 minutes.
