### PR TITLE
feat: integrate DOE flexibility data and percentage-based input

### DIFF
--- a/src/loop.jl
+++ b/src/loop.jl
@@ -55,9 +55,10 @@ function interval_loop(
         interval_start = start_index + (i - 1) * interval
         interval_end = interval_start + interval - 1
         model_kwargs["start_index"] = interval_start
+        bus_demand = _make_bus_demand(case, interval_start, interval_end)
         if demand_flexibility.enabled
             (bus_demand_flex_amt_up, bus_demand_flex_amt_dn) = _make_bus_demand_flexibility_amount(
-                case, demand_flexibility, interval_start, interval_end
+                case, demand_flexibility, interval_start, interval_end, bus_demand, sets
             )
         end
         if i == 1
@@ -86,7 +87,6 @@ function interval_loop(
             m = _build_model(m; symbolize(model_kwargs)...)
         else
             # Reassign right-hand-side of constraints to match profiles
-            bus_demand = _make_bus_demand(case, interval_start, interval_end)
             simulation_hydro = permutedims(
                 Matrix(case.hydro[interval_start:interval_end, 2:end])
             )

--- a/src/model.jl
+++ b/src/model.jl
@@ -198,9 +198,13 @@ function _make_sets(
         csv_flexible_bus_idx = [bus_id2idx[bus] for bus in csv_flexible_bus_id]
 
         # all flexible buses
-        flexible_bus_idx = sort([
-            i for i in union(doe_flexible_bus_idx, csv_flexible_bus_idx)
-        ])
+        if !isnothing(doe_flexible_bus_idx)
+            flexible_bus_idx = sort([
+                i for i in union(doe_flexible_bus_idx, csv_flexible_bus_idx)
+            ])
+        else
+            flexible_bus_idx = sort(csv_flexible_bus_idx)
+        end
         num_flexible_bus = length(flexible_bus_idx)
         flexible_load_bus_map = sparse(
             flexible_bus_idx, 1:num_flexible_bus, 1, num_bus, num_flexible_bus

--- a/src/types.jl
+++ b/src/types.jl
@@ -17,6 +17,7 @@ Base.@kwdef struct Case
     busid::Array{Int64,1}
     bus_demand::Array{Float64,1}
     bus_zone::Array{Int64,1}
+    bus_eiaid::Array{Int64,1}
 
     genid::Array{Int64,1}
     genfuel::Array{String,1}
@@ -42,6 +43,7 @@ Base.@kwdef struct Storage
 end
 
 Base.@kwdef struct DemandFlexibility
+    doe_flex_amt::Union{DataFrames.DataFrame,Nothing}
     flex_amt_up::Union{DataFrames.DataFrame,Nothing}
     flex_amt_dn::Union{DataFrames.DataFrame,Nothing}
     cost_dn::Union{DataFrames.DataFrame,Nothing}
@@ -50,6 +52,7 @@ Base.@kwdef struct DemandFlexibility
     enabled::Bool
     interval_balance::Bool
     rolling_balance::Bool
+    enable_doe_flexibility::Bool
 end
 
 Base.@kwdef struct Results
@@ -100,6 +103,8 @@ Base.@kwdef struct Sets
     num_segments::Int64
     segment_idx::UnitRange{Int64}
     ## Demand Flexibility
+    csv_flexible_bus_idx::Union{Array{Int64,1},Nothing}
+    doe_flexible_bus_idx::Union{Array{Int64,1},Nothing}
     flexible_bus_idx::Union{Array{Int64,1},Nothing}
     num_flexible_bus::Int64
     flexible_load_bus_map::Union{SparseMatrixCSC,Nothing}


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose

Integrate pre-processed EIA-ID based flexibility data from DOE flexibility data into REISE modelling.
The DOE data will be downloaded from blob storage first if not found in the case folder.
The EIA ID of buses is stored in column 18 of the bus field in case.mat. This file is manually modified for now, but in the future this info will be integrated into powersimdata.

### What the code is doing
Read the percentage based LSE flexibility, match with load buses and convert to MW amount

### Testing
run_scenario_gurobi() using TX sub-system data

### Where to look
read.jl: additional logic for reading DOE data
model.jl: convert percentage to MW 

### Time estimate
15 min
