### PR TITLE
fix: convert storage data to float

### DIFF
--- a/src/read.jl
+++ b/src/read.jl
@@ -83,11 +83,11 @@ function read_storage(filepath)::Storage
         println("...loading case_storage.mat")
         # Convert N x 1 array of strings into 1D array of Symbols (length N)
         column_symbols = Symbol.(vec(storage_mat_data["sd_table"]["colnames"]))
+        data = convert(Array{Float64,2}, storage_mat_data["sd_table"]["data"])
         storage = Dict(
             "enabled" => true,
             "gen" => storage_mat_data["gen"],
-            "sd_table" =>
-                DataFrames.DataFrame(storage_mat_data["sd_table"]["data"], column_symbols),
+            "sd_table" => DataFrames.DataFrame(data, column_symbols),
         )
     catch e
         println("File case_storage.mat not found in " * filepath)


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Fix running scenarios with storage. 

### What the code is doing
Prior to this change, we'd get the following error, even though the data could be converted to floats. This change makes that explicit by converting the array type before passing to the `DataFrame` constructor.
```
  'Julia exception: TypeError: in keyword argument storage_e0, expected Array{Float64,1}, got a value of type Array{Any,1}',
  'Stacktrace:',
  '[1] interval_loop(::Type{T} where T, ::Dict{String,Any}, ::Dict{Any,Any}, ::Int64, ::Int64, ::Int64, ::String, ::String) at /app/src/loop.jl:73',
  '[2] (::REISE.var"#146#147"{Int64,Int64,Int64,String,DataType})() at /app/src/REISE.jl:98',
  '[3] #134 at /app/src/save.jl:120 [inlined]',
  '[4] redirect_stderr(::REISE.var"#134#138"{REISE.var"#146#147"{Int64,Int64,Int64,String,DataType}}, ::IOStream) at ./stream.jl:1150',
```


### Testing
Ran a scenario using docker and reloaded the grid after it was in the analyze state. The grids before and after running the scenario are identical except for storage, which differ only in that the latter has float values in some storage columns that were previously `int`.


### Time estimate
10 min
