### PR TITLE
Replace case.mat with grid.pkl

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Format check
         run: |
           julia -e '
-          out = Cmd(`git diff --name-only`) |> read |> String
+          out = Cmd(`git diff`) |> read |> String
           if out == ""
               exit(0)
           else

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         version:
           - '1.5'
-          - 'nightly'
+          # - 'nightly'
         os:
           - ubuntu-latest
     steps:

--- a/pyreisejl/utility/call.py
+++ b/pyreisejl/utility/call.py
@@ -58,6 +58,10 @@ def _save(path, name, df):
     df.to_csv(os.path.join(path, f"{name}.csv"), index=False)
 
 
+def _save_storage(path, name, df):
+    df.to_csv(os.path.join(path, f"{name}.csv"), index=False)
+
+
 def pkl_to_csv(path):
     with open(os.path.join(path, "grid.pkl"), "rb") as f:
         grid = pickle.load(f)
@@ -66,6 +70,11 @@ def pkl_to_csv(path):
     _save(path, "bus", grid.bus)
     _save(path, "plant", grid.plant)
     _save(path, "gencost", grid.gencost["before"])
+
+    storage = grid.storage
+    if not storage["gen"].empty:
+        _save_storage(path, "StorageData", storage["StorageData"])
+        _save_storage(path, "storage_gen", storage["gen"])
 
 
 def pkl_to_case_mat(path):

--- a/pyreisejl/utility/call.py
+++ b/pyreisejl/utility/call.py
@@ -48,7 +48,7 @@ cols = {
     ],
 }
 
-drop_cols = {"gencost": ["interconnect"]}
+drop_cols = {"gencost": ["plant_id", "interconnect"]}
 
 
 def _save(path, name, df):

--- a/pyreisejl/utility/call.py
+++ b/pyreisejl/utility/call.py
@@ -48,10 +48,13 @@ cols = {
     ],
 }
 
+drop_cols = {"gencost": ["interconnect"]}
+
 
 def _save(path, name, df):
     df = df.reset_index()
     df = df.loc[:, cols.get(name, df.columns)]
+    df = df.drop(drop_cols.get(name, []), axis=1)
     df.to_csv(os.path.join(path, f"{name}.csv"), index=False)
 
 

--- a/pyreisejl/utility/converters.py
+++ b/pyreisejl/utility/converters.py
@@ -1,0 +1,99 @@
+import copy
+
+import numpy as np
+from scipy.io import savemat
+
+
+def create_case_mat(grid, filepath=None, storage_filepath=None):
+    """Export a grid to a format suitable for loading into simulation engine.
+    If optional filepath arguments are used, the results will also be saved to
+    the filepaths provided
+
+    :param powersimdata.input.grid.Grid grid: Grid instance.
+    :param str filepath: path where main grid file will be saved, if present
+    :param str storage_filepath: path where storage data file will be saved, if present.
+    :return: (*tuple*) -- the mpc data as a dictionary and the mpc storage data
+        as a dictionary, if present. The storage data will be None if not present.
+    """
+    grid = copy.deepcopy(grid)
+
+    mpc = {"mpc": {"version": "2", "baseMVA": 100.0}}
+
+    # zone
+    mpc["mpc"]["zone"] = np.array(list(grid.id2zone.items()), dtype=object)
+
+    # sub
+    sub = grid.sub.copy()
+    subid = sub.index.values[np.newaxis].T
+    mpc["mpc"]["sub"] = sub.values
+    mpc["mpc"]["subid"] = subid
+
+    # bus
+    bus = grid.bus.copy()
+    busid = bus.index.values[np.newaxis].T
+    bus.reset_index(level=0, inplace=True)
+    mpc["mpc"]["bus"] = bus.values
+    mpc["mpc"]["busid"] = busid
+
+    # bus2sub
+    bus2sub = grid.bus2sub.copy()
+    mpc["mpc"]["bus2sub"] = bus2sub.values
+
+    # plant
+    gen = grid.plant.copy()
+    genid = gen.index.values[np.newaxis].T
+    genfuel = gen.type.values[np.newaxis].T
+    genfuelcost = gen.GenFuelCost.values[np.newaxis].T
+    heatratecurve = gen[["GenIOB", "GenIOC", "GenIOD"]].values
+    gen.reset_index(inplace=True, drop=True)
+    mpc["mpc"]["gen"] = gen.values
+    mpc["mpc"]["genid"] = genid
+    mpc["mpc"]["genfuel"] = genfuel
+    mpc["mpc"]["genfuelcost"] = genfuelcost
+    mpc["mpc"]["heatratecurve"] = heatratecurve
+
+    # branch
+    branch = grid.branch.copy()
+    branchid = branch.index.values[np.newaxis].T
+    branchdevicetype = branch.branch_device_type.values[np.newaxis].T
+    branch.reset_index(inplace=True, drop=True)
+    mpc["mpc"]["branch"] = branch.values
+    mpc["mpc"]["branchid"] = branchid
+    mpc["mpc"]["branchdevicetype"] = branchdevicetype
+
+    # generation cost
+    gencost = grid.gencost.copy()
+    gencost["before"].reset_index(inplace=True, drop=True)
+    mpc["mpc"]["gencost"] = gencost["before"].values
+
+    # DC line
+    if len(grid.dcline) > 0:
+        dcline = grid.dcline.copy()
+        dclineid = dcline.index.values[np.newaxis].T
+        dcline.reset_index(inplace=True, drop=True)
+        mpc["mpc"]["dcline"] = dcline.values
+        mpc["mpc"]["dclineid"] = dclineid
+
+    # energy storage
+    mpc_storage = None
+
+    if len(grid.storage["gen"]) > 0:
+        storage = grid.storage.copy()
+
+        mpc_storage = {
+            "storage": {
+                "xgd_table": np.array([]),
+                "gen": np.array(storage["gen"].values, dtype=np.float64),
+                "sd_table": {
+                    "colnames": storage["StorageData"].columns.values[np.newaxis],
+                    "data": storage["StorageData"].values,
+                },
+            }
+        }
+
+    if filepath is not None:
+        savemat(filepath, mpc, appendmat=False)
+        if mpc_storage is not None:
+            savemat(storage_filepath, mpc_storage, appendmat=False)
+
+    return mpc, mpc_storage

--- a/pyreisejl/utility/converters.py
+++ b/pyreisejl/utility/converters.py
@@ -46,6 +46,21 @@ def create_case_mat(grid, filepath=None, storage_filepath=None):
     genfuelcost = gen.GenFuelCost.values[np.newaxis].T
     heatratecurve = gen[["GenIOB", "GenIOC", "GenIOD"]].values
     gen.reset_index(inplace=True, drop=True)
+    gen.drop(
+        columns=[
+            "type",
+            "interconnect",
+            "lat",
+            "lon",
+            "zone_id",
+            "zone_name",
+            "GenFuelCost",
+            "GenIOB",
+            "GenIOC",
+            "GenIOD",
+        ],
+        inplace=True,
+    )
     mpc["mpc"]["gen"] = gen.values
     mpc["mpc"]["genid"] = genid
     mpc["mpc"]["genfuel"] = genfuel
@@ -64,6 +79,7 @@ def create_case_mat(grid, filepath=None, storage_filepath=None):
     # generation cost
     gencost = grid.gencost.copy()
     gencost["before"].reset_index(inplace=True, drop=True)
+    gencost["before"].drop(columns=["interconnect"], inplace=True)
     mpc["mpc"]["gencost"] = gencost["before"].values
 
     # DC line

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ scipy~=1.6
 tqdm~=4.29.1
 pytest
 Flask~=2.0
+powersimdata~=0.5.4

--- a/src/read.jl
+++ b/src/read.jl
@@ -71,6 +71,66 @@ function read_case(filepath)
     return case
 end
 
+function read_case_v2(filepath)
+    println("Reading from folder: " * filepath)
+
+    # New case.mat analog
+    case = Dict()
+
+    # AC branches
+    branch = CSV.File(joinpath(filepath, "branch.csv"))
+    case["branchid"] = convert(Array{Int,1}, branch.branch_id)
+    case["branch_from"] = convert(Array{Int,1}, branch.from_bus_id)
+    case["branch_to"] = convert(Array{Int,1}, branch.to_bus_id)
+    case["branch_reactance"] = convert(Array{Float64,1}, branch.x)
+    case["branch_rating"] = convert(Array{Float64,1}, branch.rateA)
+
+    # DC branches
+    dcline = CSV.File(joinpath(filepath, "dcline.csv"))
+    case["dcline_id"] = convert(Array{Int,1}, dcline.dcline_id)
+    case["dcline_from"] = convert(Array{Int,1}, dcline.from_bus_id)
+    case["dcline_to"] = convert(Array{Int,1}, dcline.to_bus_id)
+    case["dcline_pmin"] = convert(Array{Float64,1}, dcline.Pmin)
+    case["dcline_pmax"] = convert(Array{Float64,1}, branch.Pmax)
+
+    # Buses
+    bus = CSV.File(joinpath(filepath, "bus.csv"))
+    case["busid"] = convert(Array{Int,1}, bus.bus_id)
+    case["bus_demand"] = convert(Array{Float64,1}, bus.Pd)
+    case["bus_zone"] = convert(Array{Int,1}, bus.zone_id)
+
+    # Generators
+    plant = CSV.File(joinpath(filepath, "plant.csv"))
+    case["genid"] = convert(Array{Int,1}, plant.plant_id)
+    case["genfuel"] = convert(Array{String,1}, plant.type)
+    case["gen_bus"] = convert(Array{Int,1}, plant.bus_id)
+
+    # gen_status::BitArray{1}
+    case["gen_status"] = convert(Array{Int,1}, plant.status)
+
+    case["gen_pmax"] = convert(Array{Float64,1}, plant.Pmax)
+    case["gen_pmin"] = convert(Array{Float64,1}, plant.Pmin)
+    case["gen_ramp30"] = convert(Array{Float64,1}, plant.ramp_30)
+
+    # TODO Generator costs
+    # case["gencost"] = mpc["gencost"]
+
+    # Load all relevant profile data from CSV files
+    println("...loading demand.csv")
+    case["demand"] = DataFrames.DataFrame(CSV.File(joinpath(filepath, "demand.csv")))
+
+    println("...loading hydro.csv")
+    case["hydro"] = DataFrames.DataFrame(CSV.File(joinpath(filepath, "hydro.csv")))
+
+    println("...loading wind.csv")
+    case["wind"] = DataFrames.DataFrame(CSV.File(joinpath(filepath, "wind.csv")))
+
+    println("...loading solar.csv")
+    case["solar"] = DataFrames.DataFrame(CSV.File(joinpath(filepath, "solar.csv")))
+
+    return case
+end
+
 """Read input matfile (if present), return parsed data in a Storage struct."""
 function read_storage(filepath)::Storage
     # Fallback dataframe, in case there's no case_storage.mat file

--- a/src/read.jl
+++ b/src/read.jl
@@ -1,4 +1,4 @@
-"""Read REISE input matfiles, return parsed relevant data in a Dict."""
+"""Read REISE input files, return parsed relevant data in a Dict."""
 function read_case(filepath)
     println("Reading from folder: " * filepath)
 
@@ -38,9 +38,8 @@ function read_case(filepath)
     case["gen_ramp30"] = convert(Array{Float64,1}, plant.ramp_30)
 
     # Generator costs
-    gencost = CSV.File(joinpath(filepath, "gencost.csv"))
-    df = DataFrames.DataFrame(gencost)
-    case["gencost"] = convert(Matrix{Float64}, df)
+    gencost = DataFrames.DataFrame(CSV.File(joinpath(filepath, "gencost.csv")))
+    case["gencost"] = convert(Matrix{Float64}, gencost)
 
     # Load all relevant profile data from CSV files
     println("...loading demand.csv")
@@ -58,26 +57,23 @@ function read_case(filepath)
     return case
 end
 
-"""Read input matfile (if present), return parsed data in a Storage struct."""
+"""Read input file (if present), return parsed data in a Storage struct."""
 function read_storage(filepath)::Storage
-    # Fallback dataframe, in case there's no case_storage.mat file
+    # Fallback dataframe, in case there's no input files
     storage = Dict(
         "enabled" => false, "gen" => zeros(0, 21), "sd_table" => DataFrames.DataFrame()
     )
     try
-        case_storage_file = MAT.matopen(joinpath(filepath, "case_storage.mat"))
-        storage_mat_data = read(case_storage_file, "storage")
-        println("...loading case_storage.mat")
+        println("...loading storage")
+        gen = DataFrames.DataFrame(CSV.File(joinpath(filepath, "storage_gen.csv")))
+
         # Convert N x 1 array of strings into 1D array of Symbols (length N)
-        column_symbols = Symbol.(vec(storage_mat_data["sd_table"]["colnames"]))
-        data = convert(Array{Float64,2}, storage_mat_data["sd_table"]["data"])
+        data = DataFrames.DataFrame(CSV.File(joinpath(filepath, "StorageData.csv")))
         storage = Dict(
-            "enabled" => true,
-            "gen" => storage_mat_data["gen"],
-            "sd_table" => DataFrames.DataFrame(data, column_symbols),
+            "enabled" => true, "gen" => convert(Array{Float64,2}, gen), "sd_table" => data
         )
-    catch e
-        println("File case_storage.mat not found in " * filepath)
+    catch
+        println("Storage information not found in " * filepath)
     end
 
     # Convert Dict to NamedTuple
@@ -136,12 +132,12 @@ function read_demand_flexibility(filepath, interval)::DemandFlexibility
         for k in keys(demand_flexibility_params_warns)
             try
                 demand_flexibility[k] = demand_flexibility_parameters[1, k]
-            catch e
+            catch
                 println(demand_flexibility_params_warns[k])
             end
         end
 
-    catch e
+    catch
         println("Demand flexibility parameters not found in " * filepath)
         println(
             "Demand flexibility parameters will default to allowing demand flexibility " *
@@ -176,7 +172,7 @@ function read_demand_flexibility(filepath, interval)::DemandFlexibility
                     CSV.File(joinpath(filepath, "demand_flexibility_" * s * ".csv"))
                 )
                 println("...loading demand flexibility " * s * " profiles")
-            catch e
+            catch
                 println("Demand flexibility " * s * " profile not found in " * filepath)
             end
 
@@ -186,7 +182,7 @@ function read_demand_flexibility(filepath, interval)::DemandFlexibility
                     CSV.File(joinpath(filepath, "demand_flexibility_cost_" * s * ".csv"))
                 )
                 println("...loading demand flexibility " * s * "-shift cost profiles")
-            catch e
+            catch
                 println(
                     "Demand flexibility " *
                     s *

--- a/src/read.jl
+++ b/src/read.jl
@@ -104,16 +104,15 @@ function read_case_v2(filepath)
     case["genid"] = convert(Array{Int,1}, plant.plant_id)
     case["genfuel"] = convert(Array{String,1}, plant.type)
     case["gen_bus"] = convert(Array{Int,1}, plant.bus_id)
-
-    # gen_status::BitArray{1}
-    case["gen_status"] = convert(Array{Int,1}, plant.status)
-
+    case["gen_status"] = convert(BitArray{1}, plant.status)
     case["gen_pmax"] = convert(Array{Float64,1}, plant.Pmax)
     case["gen_pmin"] = convert(Array{Float64,1}, plant.Pmin)
     case["gen_ramp30"] = convert(Array{Float64,1}, plant.ramp_30)
 
-    # TODO Generator costs
-    # case["gencost"] = mpc["gencost"]
+    # Generator costs
+    gencost = CSV.File(joinpath(filepath, "gencost.csv"))
+    df = DataFrames.DataFrame(gencost)
+    case["gencost"] = convert(Matrix{Float64}, df)
 
     # Load all relevant profile data from CSV files
     println("...loading demand.csv")

--- a/src/read.jl
+++ b/src/read.jl
@@ -1,6 +1,4 @@
 """Read REISE input matfiles, return parsed relevant data in a Dict."""
-
-
 function read_case(filepath)
     println("Reading from folder: " * filepath)
 
@@ -17,7 +15,7 @@ function read_case(filepath)
 
     # DC branches
     dcline = CSV.File(joinpath(filepath, "dcline.csv"))
-    case["dcline_id"] = convert(Array{Int,1}, dcline.dcline_id)
+    case["dclineid"] = convert(Array{Int,1}, dcline.dcline_id)
     case["dcline_from"] = convert(Array{Int,1}, dcline.from_bus_id)
     case["dcline_to"] = convert(Array{Int,1}, dcline.to_bus_id)
     case["dcline_pmin"] = convert(Array{Float64,1}, dcline.Pmin)

--- a/src/read.jl
+++ b/src/read.jl
@@ -1,77 +1,7 @@
 """Read REISE input matfiles, return parsed relevant data in a Dict."""
+
+
 function read_case(filepath)
-    println("Reading from folder: " * filepath)
-
-    println("...loading case.mat")
-    case_mat_file = MAT.matopen(joinpath(filepath, "case.mat"))
-    mpc = read(case_mat_file, "mpc")
-
-    # New case.mat analog
-    case = Dict()
-
-    # AC branches
-    # dropdims() will remove extraneous dimension
-    case["branchid"] = dropdims(mpc["branchid"]; dims=2)
-    # convert() will convert float array to int array
-    case["branch_from"] = convert(Array{Int,1}, mpc["branch"][:, 1])
-    case["branch_to"] = convert(Array{Int,1}, mpc["branch"][:, 2])
-    case["branch_reactance"] = mpc["branch"][:, 4]
-    case["branch_rating"] = mpc["branch"][:, 6]
-
-    # DC branches
-    if "dcline" in keys(mpc)
-        if isa(mpc["dclineid"], Int)
-            case["dclineid"] = Int64[mpc["dclineid"]]
-        else
-            case["dclineid"] = dropdims(mpc["dclineid"]; dims=2)
-        end
-        case["dcline_from"] = convert(Array{Int,1}, mpc["dcline"][:, 1])
-        case["dcline_to"] = convert(Array{Int,1}, mpc["dcline"][:, 2])
-        case["dcline_pmin"] = mpc["dcline"][:, 10]
-        case["dcline_pmax"] = mpc["dcline"][:, 11]
-    else
-        case["dclineid"] = Int64[]
-        case["dcline_from"] = Int64[]
-        case["dcline_to"] = Int64[]
-        case["dcline_pmin"] = Float64[]
-        case["dcline_pmax"] = Float64[]
-    end
-
-    # Buses
-    case["busid"] = convert(Array{Int,1}, mpc["bus"][:, 1])
-    case["bus_demand"] = mpc["bus"][:, 3]
-    case["bus_zone"] = convert(Array{Int,1}, mpc["bus"][:, 7])
-
-    # Generators
-    case["genid"] = dropdims(mpc["genid"]; dims=2)
-    genfuel = dropdims(mpc["genfuel"]; dims=2)
-    case["genfuel"] = convert(Array{String,1}, genfuel)
-    case["gen_bus"] = convert(Array{Int,1}, mpc["gen"][:, 1])
-    case["gen_status"] = mpc["gen"][:, 8]
-    case["gen_pmax"] = mpc["gen"][:, 9]
-    case["gen_pmin"] = mpc["gen"][:, 10]
-    case["gen_ramp30"] = mpc["gen"][:, 19]
-
-    # Generator costs
-    case["gencost"] = mpc["gencost"]
-
-    # Load all relevant profile data from CSV files
-    println("...loading demand.csv")
-    case["demand"] = DataFrames.DataFrame(CSV.File(joinpath(filepath, "demand.csv")))
-
-    println("...loading hydro.csv")
-    case["hydro"] = DataFrames.DataFrame(CSV.File(joinpath(filepath, "hydro.csv")))
-
-    println("...loading wind.csv")
-    case["wind"] = DataFrames.DataFrame(CSV.File(joinpath(filepath, "wind.csv")))
-
-    println("...loading solar.csv")
-    case["solar"] = DataFrames.DataFrame(CSV.File(joinpath(filepath, "solar.csv")))
-
-    return case
-end
-
-function read_case_v2(filepath)
     println("Reading from folder: " * filepath)
 
     # New case.mat analog
@@ -91,7 +21,7 @@ function read_case_v2(filepath)
     case["dcline_from"] = convert(Array{Int,1}, dcline.from_bus_id)
     case["dcline_to"] = convert(Array{Int,1}, dcline.to_bus_id)
     case["dcline_pmin"] = convert(Array{Float64,1}, dcline.Pmin)
-    case["dcline_pmax"] = convert(Array{Float64,1}, branch.Pmax)
+    case["dcline_pmax"] = convert(Array{Float64,1}, dcline.Pmax)
 
     # Buses
     bus = CSV.File(joinpath(filepath, "bus.csv"))


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Remove dependence on column indices when reading case.mat by converting a grid.pkl to csv files with the appropriate columns, and accessing columns by name.

### What the code is doing
* Convert grid.pkl to csv files and read those in read.jl
* Keep the case.mat which is still used by `save_input_mat`

### Testing
Ran a scenario in a container

### Time estimate
30 mins
