### PR TITLE
ci: update docker build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           push: true
           tags: |


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Attempt to fix permissions error when pushing the docker image.

### What the code is doing
Update actions versions and switch to using the `GITHUB_TOKEN` which is the recommended practice. See [docs](https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-github-packages). I also added this repository in the package settings for the `reisejl` image (done [here](https://github.com/orgs/Breakthrough-Energy/packages/container/reisejl/settings)) which should authorize workflows in this repo using the token to push packages. 

### Testing
Not sure how to test without merging.

### Time estimate
2 min
