### PR TITLE
fix: use dataframe for storage.gen

### DIFF
--- a/pyreisejl/utility/converters.py
+++ b/pyreisejl/utility/converters.py
@@ -3,26 +3,14 @@ import os
 import pickle
 
 cols = {
-    "branch": ["branch_id", "from_bus_id", "to_bus_id", "x", "rateA"],
-    "dcline": ["dcline_id", "from_bus_id", "to_bus_id", "Pmin", "Pmax"],
-    "bus": ["bus_id", "Pd", "zone_id"],
-    "plant": [
-        "plant_id",
-        "bus_id",
-        "status",
-        "Pmin",
-        "Pmax",
-        "type",
-        "ramp_30",
-        "GenFuelCost",
-        "GenIOB",
-        "GenIOC",
-        "GenIOD",
-    ],
-    "storage_gen": ["bus_id", "Pmin", "Pmax"],
+    "branch": "branch_id from_bus_id to_bus_id x rateA".split(),
+    "dcline": "dcline_id from_bus_id to_bus_id Pmin Pmax".split(),
+    "bus": "bus_id Pd zone_id".split(),
+    "plant": "plant_id bus_id status Pmin Pmax type ramp_30 GenFuelCost GenIOB GenIOC GenIOD".split(),
+    "storage_gen": "bus_id Pmin Pmax".split(),
 }
 
-drop_cols = {"gencost_before": ["plant_id", "interconnect"]}
+drop_cols = {"gencost_before": "plant_id interconnect".split()}
 drop_cols["gencost_after"] = drop_cols["gencost_before"]
 
 

--- a/pyreisejl/utility/converters.py
+++ b/pyreisejl/utility/converters.py
@@ -19,6 +19,7 @@ cols = {
         "GenIOC",
         "GenIOD",
     ],
+    "storage_gen": ["bus_id", "Pmin", "Pmax"],
 }
 
 drop_cols = {"gencost_before": ["plant_id", "interconnect"]}
@@ -32,10 +33,6 @@ def _save(path, name, df):
     df.to_csv(os.path.join(path, f"{name}.csv"), index=False)
 
 
-def _save_storage(path, name, df):
-    df.to_csv(os.path.join(path, f"{name}.csv"), index=False)
-
-
 def _pkl_to_csv(path, grid):
     _save(path, "branch", grid.branch)
     _save(path, "dcline", grid.dcline)
@@ -46,8 +43,8 @@ def _pkl_to_csv(path, grid):
 
     storage = grid.storage
     if not storage["gen"].empty:
-        _save_storage(path, "StorageData", storage["StorageData"])
-        _save_storage(path, "storage_gen", storage["gen"])
+        _save(path, "StorageData", storage["StorageData"])
+        _save(path, "storage_gen", storage["gen"])
 
 
 def _pkl_to_json(path, grid):

--- a/src/model.jl
+++ b/src/model.jl
@@ -290,7 +290,7 @@ function _add_constraint_power_balance!(
     end
     withdrawals = JuMP.@expression(m, bus_demand)
     if storage.enabled
-        storage_bus_idx = [sets.bus_id2idx[b] for b in storage.gen[:, 1]]
+        storage_bus_idx = [sets.bus_id2idx[b] for b in storage.gen.bus_id]
         storage_map = sparse(
             storage_bus_idx, sets.storage_idx, 1, sets.num_bus, sets.num_storage
         )::SparseMatrixCSC
@@ -668,9 +668,6 @@ function _build_model(
     storage_e0::Array{Float64,1}=Float64[],
     init_shifted_demand::Array{Float64,1}=Float64[],
 )::JuMP.Model
-    # Positional indices from mpc.gen
-    PMAX = 9
-    PMIN = 10
     println("building sets: ", Dates.now())
     # Sets - time periods
     hour_idx = 1:interval_length
@@ -712,8 +709,8 @@ function _build_model(
         )
     end
     if storage.enabled
-        storage_max_dis = storage.gen[:, PMAX]
-        storage_max_chg = -1 * storage.gen[:, PMIN]
+        storage_max_dis = storage.gen.Pmax
+        storage_max_chg = -1 * storage.gen.Pmin
         storage_min_energy = storage.sd_table.MinStorageLevel
         storage_max_energy = storage.sd_table.MaxStorageLevel
         JuMP.@variables(

--- a/src/read.jl
+++ b/src/read.jl
@@ -86,17 +86,15 @@ end
 function read_storage(filepath)::Storage
     # Fallback dataframe, in case there's no input files
     storage = Dict(
-        "enabled" => false, "gen" => zeros(0, 21), "sd_table" => DataFrames.DataFrame()
+        "enabled" => false,
+        "gen" => DataFrames.DataFrame(),
+        "sd_table" => DataFrames.DataFrame(),
     )
     try
         println("...loading storage")
         gen = DataFrames.DataFrame(CSV.File(joinpath(filepath, "storage_gen.csv")))
-
-        # Convert N x 1 array of strings into 1D array of Symbols (length N)
         data = DataFrames.DataFrame(CSV.File(joinpath(filepath, "StorageData.csv")))
-        storage = Dict(
-            "enabled" => true, "gen" => convert(Array{Float64,2}, gen), "sd_table" => data
-        )
+        storage = Dict("enabled" => true, "gen" => gen, "sd_table" => data)
     catch
         println("Storage information not found in " * filepath)
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -42,7 +42,7 @@ end
 
 Base.@kwdef struct Storage
     enabled::Bool
-    gen::Array{Float64,2}
+    gen::DataFrames.DataFrame
     sd_table::DataFrames.DataFrame
 end
 


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Loosen restriction on column types for storage (specifically string bus_id) to handle both usa_tamu and europe_tub grids. 

### What the code is doing
Change `storage.gen` to a data frame, rather than attempting conversion to a float array. Also filter the columns we extract from the original `grid.pkl` to just the ones we use (bus_id, Pmin, Pmax). 

### Testing
Ran a usa_tamu scenario with storage, ensured storage is loaded and results files include storage.


### Time estimate
5 min
