### PR TITLE
refactor: reduce indexing by using values directly

### DIFF
--- a/src/loop.jl
+++ b/src/loop.jl
@@ -106,24 +106,17 @@ function interval_loop(
                     getfield(case, Symbol(p))[interval_start:interval_end, 2:end]
                 )
             end
-            for g in keys(sets.profile_resources_num_rep)
+            for g in values(sets.profile_resources_num_rep)
                 for h in 1:interval
-                    for i in
-                        1:length(
-                        sets.profile_resources_idx[sets.profile_resources_num_rep[g]]
-                    )
+                    for i in 1:length(sets.profile_resources_idx[g])
                         JuMP.set_normalized_rhs(
                             m[:profile_upper_bound][g, i, h],
-                            simulation_profile[sets.profile_to_group[sets.profile_resources_num_rep[g]]][
-                                h, i
-                            ],
+                            simulation_profile[sets.profile_to_group[g]][h, i],
                         )
                         JuMP.set_normalized_rhs(
                             m[:profile_lower_bound][g, i, h],
-                            case.pmin_as_share_of_pmax[sets.profile_resources_num_rep[g]] *
-                            simulation_profile[sets.profile_to_group[sets.profile_resources_num_rep[g]]][
-                                h, i
-                            ],
+                            case.pmin_as_share_of_pmax[g] *
+                            simulation_profile[sets.profile_to_group[g]][h, i],
                         )
                     end
                 end

--- a/src/loop.jl
+++ b/src/loop.jl
@@ -106,7 +106,7 @@ function interval_loop(
                     getfield(case, Symbol(p))[interval_start:interval_end, 2:end]
                 )
             end
-            for g in values(sets.profile_resources_num_rep)
+            for g in case.profile_resources
                 for h in 1:interval
                     for i in 1:length(sets.profile_resources_idx[g])
                         JuMP.set_normalized_rhs(

--- a/src/model.jl
+++ b/src/model.jl
@@ -542,12 +542,12 @@ function _add_profile_generator_limits!(
     JuMP.@constraint(
         m,
         profile_upper_bound[
-            g in keys(sets.profile_resources_num_rep),
-            i in 1:length(sets.profile_resources_idx[sets.profile_resources_num_rep[g]]),
+            g in values(sets.profile_resources_num_rep),
+            i in 1:length(sets.profile_resources_idx[g]),
             h in hour_idx,
         ],
-        m[:pg][sets.profile_resources_idx[sets.profile_resources_num_rep[g]][i], h] <=
-            simulation_profile[sets.profile_to_group[sets.profile_resources_num_rep[g]]][h, i],
+        m[:pg][sets.profile_resources_idx[g][i], h] <=
+            simulation_profile[sets.profile_to_group[g]][h, i],
     )
 
     # Set the lower bounds, establishing PMIN as a share of PMAX
@@ -555,15 +555,13 @@ function _add_profile_generator_limits!(
     JuMP.@constraint(
         m,
         profile_lower_bound[
-            g in keys(sets.profile_resources_num_rep),
-            i in 1:length(sets.profile_resources_idx[sets.profile_resources_num_rep[g]]),
+            g in values(sets.profile_resources_num_rep),
+            i in 1:length(sets.profile_resources_idx[g]),
             h in hour_idx,
         ],
-        m[:pg][sets.profile_resources_idx[sets.profile_resources_num_rep[g]][i], h] >= (
-            case.pmin_as_share_of_pmax[sets.profile_resources_num_rep[g]] *
-            simulation_profile[sets.profile_to_group[sets.profile_resources_num_rep[g]]][
-                h, i
-            ]
+        m[:pg][sets.profile_resources_idx[g][i], h] >= (
+            case.pmin_as_share_of_pmax[g] *
+            simulation_profile[sets.profile_to_group[g]][h, i]
         ),
     )
 end

--- a/src/model.jl
+++ b/src/model.jl
@@ -179,12 +179,6 @@ function _make_sets(
         profile_resources_idx[g] = gen_idx[findall(case.genfuel .== g)]
     end
 
-    # Create index for different profile-based resource types
-    profile_resources_num_rep = Dict{Int64,String}()
-    for i in 1:length(case.profile_resources)
-        profile_resources_num_rep[i] = case.profile_resources[i]
-    end
-
     # Create mapping between individual profile-based resources and their resource group
     profile_to_group = Dict{String,String}(
         v => k for k in keys(case.group_profile_resources) for
@@ -255,7 +249,6 @@ function _make_sets(
         num_segments=num_segments,
         segment_idx=segment_idx,
         profile_resources_idx=profile_resources_idx,
-        profile_resources_num_rep=profile_resources_num_rep,
         profile_to_group=profile_to_group,
         num_storage=num_storage,
         storage_idx=storage_idx,
@@ -542,7 +535,7 @@ function _add_profile_generator_limits!(
     JuMP.@constraint(
         m,
         profile_upper_bound[
-            g in values(sets.profile_resources_num_rep),
+            g in case.profile_resources,
             i in 1:length(sets.profile_resources_idx[g]),
             h in hour_idx,
         ],
@@ -555,7 +548,7 @@ function _add_profile_generator_limits!(
     JuMP.@constraint(
         m,
         profile_lower_bound[
-            g in values(sets.profile_resources_num_rep),
+            g in case.profile_resources,
             i in 1:length(sets.profile_resources_idx[g]),
             h in hour_idx,
         ],

--- a/src/types.jl
+++ b/src/types.jl
@@ -102,7 +102,6 @@ Base.@kwdef struct Sets
     segment_idx::UnitRange{Int64}
     # Profile-based generator subsets
     profile_resources_idx::Dict{String,Array{Int64,1}}
-    profile_resources_num_rep::Dict{Int64,String}
     profile_to_group::Dict{String,String}
     # Demand Flexibility
     flexible_bus_idx::Union{Array{Int64,1},Nothing}


### PR DESCRIPTION
### Purpose
Readability improvement. 

### What the code is doing
Simplify the constraints by using julia's builtin `values()` function to remove the extra dict lookup. 

### Testing
Ran a 4 day europe pcm which completed successfully.

### Time estimate
5 min
