### PR TITLE
Generalize type handling to support europe grid

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -6,10 +6,10 @@ Given a Case object, build a sparse matrix representing generator topology.
 function _make_gen_map(case::Case)::SparseMatrixCSC
     num_bus = length(case.busid)
     bus_idx = 1:num_bus
-    bus_id2idx = Dict(case.busid .=> bus_idx)
+    bus_id2idx = Dict(string.(case.busid) .=> bus_idx)
     num_gen = length(case.genid)
     gen_idx = 1:num_gen
-    gen_bus_idx = [bus_id2idx[b] for b in case.gen_bus]
+    gen_bus_idx = [bus_id2idx[string(b)] for b in case.gen_bus]
     gen_map = sparse(gen_bus_idx, gen_idx, 1, num_bus, num_gen)
     return gen_map
 end
@@ -25,11 +25,11 @@ function _make_branch_map(case::Case)::SparseMatrixCSC
     num_bus = length(case.busid)
     branch_idx = 1:num_branch
     bus_idx = 1:num_bus
-    bus_id2idx = Dict(case.busid .=> bus_idx)
+    bus_id2idx = Dict(string.(case.busid) .=> bus_idx)
     all_branch_to = vcat(case.branch_to, case.dcline_to)
     all_branch_from = vcat(case.branch_from, case.dcline_from)
-    branch_to_idx = [bus_id2idx[b] for b in all_branch_to]
-    branch_from_idx = [bus_id2idx[b] for b in all_branch_from]
+    branch_to_idx = [bus_id2idx[string(b)] for b in all_branch_to]
+    branch_from_idx = [bus_id2idx[string(b)] for b in all_branch_from]
     branches_to = sparse(branch_to_idx, branch_idx, 1, num_bus, num_branch)
     branches_from = sparse(branch_from_idx, branch_idx, -1, num_bus, num_branch)
     branch_map = branches_to + branches_from
@@ -139,7 +139,7 @@ function _make_sets(
     # Sets - Buses
     num_bus = length(case.busid)
     bus_idx = 1:num_bus
-    bus_id2idx = Dict(case.busid .=> bus_idx)
+    bus_id2idx = Dict(string.(case.busid) .=> bus_idx)
     load_bus_idx = findall(case.bus_demand .> 0)
     num_load_bus = length(load_bus_idx)
     load_bus_map = sparse(load_bus_idx, 1:num_load_bus, 1, num_bus, num_load_bus)
@@ -153,8 +153,8 @@ function _make_sets(
     noninf_branch_idx = findall(branch_rating .!= Inf)
     all_branch_to = vcat(case.branch_to, case.dcline_to)
     all_branch_from = vcat(case.branch_from, case.dcline_from)
-    branch_to_idx = Int64[bus_id2idx[b] for b in all_branch_to]
-    branch_from_idx = Int64[bus_id2idx[b] for b in all_branch_from]
+    branch_to_idx = Int64[bus_id2idx[string(b)] for b in all_branch_to]
+    branch_from_idx = Int64[bus_id2idx[string(b)] for b in all_branch_from]
 
     # Sets - generators
     num_gen = length(case.genid)
@@ -202,7 +202,7 @@ function _make_sets(
         # assume each flexible bus can go up/dn, so only use the Dataframe for up
         csv_flexible_bus_str = names(demand_flexibility.flex_amt_up)[2:end]
         csv_flexible_bus_id = [parse(Int64, bus) for bus in csv_flexible_bus_str]
-        csv_flexible_bus_idx = [bus_id2idx[bus] for bus in csv_flexible_bus_id]
+        csv_flexible_bus_idx = [bus_id2idx[string(bus)] for bus in csv_flexible_bus_id]
 
         # all flexible buses
         if !isnothing(doe_flexible_bus_idx)
@@ -283,7 +283,7 @@ function _add_constraint_power_balance!(
     end
     withdrawals = JuMP.@expression(m, bus_demand)
     if storage.enabled
-        storage_bus_idx = [sets.bus_id2idx[b] for b in storage.gen.bus_id]
+        storage_bus_idx = [sets.bus_id2idx[string(b)] for b in storage.gen.bus_id]
         storage_map = sparse(
             storage_bus_idx, sets.storage_idx, 1, sets.num_bus, sets.num_storage
         )::SparseMatrixCSC

--- a/src/read.jl
+++ b/src/read.jl
@@ -1,4 +1,6 @@
 """Read REISE input files, return parsed relevant data in a Case object."""
+IntOrString = Union{Int,AbstractString}
+
 function read_case(filepath)
     println("Reading from folder: " * filepath)
 
@@ -7,23 +9,23 @@ function read_case(filepath)
 
     # AC branches
     branch = CSV.File(joinpath(filepath, "branch.csv"))
-    case["branchid"] = convert(Array{Int,1}, branch.branch_id)
-    case["branch_from"] = convert(Array{String,1}, branch.from_bus_id)
-    case["branch_to"] = convert(Array{String,1}, branch.to_bus_id)
+    case["branchid"] = convert(Array{IntOrString,1}, branch.branch_id)
+    case["branch_from"] = convert(Array{IntOrString,1}, branch.from_bus_id)
+    case["branch_to"] = convert(Array{IntOrString,1}, branch.to_bus_id)
     case["branch_reactance"] = convert(Array{Float64,1}, branch.x)
     case["branch_rating"] = convert(Array{Float64,1}, branch.rateA)
 
     # DC branches
     dcline = CSV.File(joinpath(filepath, "dcline.csv"))
-    case["dclineid"] = convert(Array{String,1}, dcline.dcline_id)
-    case["dcline_from"] = convert(Array{String,1}, dcline.from_bus_id)
-    case["dcline_to"] = convert(Array{String,1}, dcline.to_bus_id)
+    case["dclineid"] = convert(Array{IntOrString,1}, dcline.dcline_id)
+    case["dcline_from"] = convert(Array{IntOrString,1}, dcline.from_bus_id)
+    case["dcline_to"] = convert(Array{IntOrString,1}, dcline.to_bus_id)
     case["dcline_pmin"] = convert(Array{Float64,1}, dcline.Pmin)
     case["dcline_pmax"] = convert(Array{Float64,1}, dcline.Pmax)
 
     # Buses
     bus = CSV.File(joinpath(filepath, "bus.csv"))
-    case["busid"] = convert(Array{String,1}, bus.bus_id)
+    case["busid"] = convert(Array{IntOrString,1}, bus.bus_id)
     case["bus_demand"] = convert(Array{Float64,1}, bus.Pd)
     case["bus_zone"] = convert(Array{Int,1}, bus.zone_id)
     try
@@ -34,9 +36,9 @@ function read_case(filepath)
 
     # Generators
     plant = CSV.File(joinpath(filepath, "plant.csv"))
-    case["genid"] = convert(Array{String,1}, plant.plant_id)
+    case["genid"] = convert(Array{IntOrString,1}, plant.plant_id)
     case["genfuel"] = convert(Array{String,1}, plant.type)
-    case["gen_bus"] = convert(Array{String,1}, plant.bus_id)
+    case["gen_bus"] = convert(Array{IntOrString,1}, plant.bus_id)
     case["gen_status"] = convert(BitArray{1}, plant.status)
     case["gen_pmax"] = convert(Array{Float64,1}, plant.Pmax)
     case["gen_pmin"] = convert(Array{Float64,1}, plant.Pmin)

--- a/src/read.jl
+++ b/src/read.jl
@@ -8,22 +8,22 @@ function read_case(filepath)
     # AC branches
     branch = CSV.File(joinpath(filepath, "branch.csv"))
     case["branchid"] = convert(Array{Int,1}, branch.branch_id)
-    case["branch_from"] = convert(Array{Int,1}, branch.from_bus_id)
-    case["branch_to"] = convert(Array{Int,1}, branch.to_bus_id)
+    case["branch_from"] = convert(Array{String,1}, branch.from_bus_id)
+    case["branch_to"] = convert(Array{String,1}, branch.to_bus_id)
     case["branch_reactance"] = convert(Array{Float64,1}, branch.x)
     case["branch_rating"] = convert(Array{Float64,1}, branch.rateA)
 
     # DC branches
     dcline = CSV.File(joinpath(filepath, "dcline.csv"))
-    case["dclineid"] = convert(Array{Int,1}, dcline.dcline_id)
-    case["dcline_from"] = convert(Array{Int,1}, dcline.from_bus_id)
-    case["dcline_to"] = convert(Array{Int,1}, dcline.to_bus_id)
+    case["dclineid"] = convert(Array{String,1}, dcline.dcline_id)
+    case["dcline_from"] = convert(Array{String,1}, dcline.from_bus_id)
+    case["dcline_to"] = convert(Array{String,1}, dcline.to_bus_id)
     case["dcline_pmin"] = convert(Array{Float64,1}, dcline.Pmin)
     case["dcline_pmax"] = convert(Array{Float64,1}, dcline.Pmax)
 
     # Buses
     bus = CSV.File(joinpath(filepath, "bus.csv"))
-    case["busid"] = convert(Array{Int,1}, bus.bus_id)
+    case["busid"] = convert(Array{String,1}, bus.bus_id)
     case["bus_demand"] = convert(Array{Float64,1}, bus.Pd)
     case["bus_zone"] = convert(Array{Int,1}, bus.zone_id)
     try
@@ -34,9 +34,9 @@ function read_case(filepath)
 
     # Generators
     plant = CSV.File(joinpath(filepath, "plant.csv"))
-    case["genid"] = convert(Array{Int,1}, plant.plant_id)
+    case["genid"] = convert(Array{String,1}, plant.plant_id)
     case["genfuel"] = convert(Array{String,1}, plant.type)
-    case["gen_bus"] = convert(Array{Int,1}, plant.bus_id)
+    case["gen_bus"] = convert(Array{String,1}, plant.bus_id)
     case["gen_status"] = convert(BitArray{1}, plant.status)
     case["gen_pmax"] = convert(Array{Float64,1}, plant.Pmax)
     case["gen_pmin"] = convert(Array{Float64,1}, plant.Pmin)

--- a/src/read.jl
+++ b/src/read.jl
@@ -408,7 +408,7 @@ function reformat_demand_flexibility_input(
 
             # numeric ID corresponding to bus columns
             flexible_bus_id = [parse(Int64, flexible_str[i]) for i in bus_columns_idx]
-            flexible_bus_idx = [sets.bus_id2idx[x] for x in flexible_bus_id]
+            flexible_bus_idx = [sets.bus_id2idx[string(x)] for x in flexible_bus_id]
             flexible_bus_num = length(flexible_bus_id)
 
             # remove bus columns from zone to bus mapping
@@ -533,9 +533,10 @@ function reformat_demand_flexibility_input(
                 # assume each flexible bus can go up/dn, so only use the Dataframe for up
                 csv_flexible_bus_str = names(demand_flexibility_updated["flex_amt_up"])[2:end]
                 csv_flexible_bus_id = [parse(Int64, bus) for bus in csv_flexible_bus_str]
-                csv_flexible_bus_idx = [sets.bus_id2idx[bus] for bus in csv_flexible_bus_id]
+                csv_flexible_bus_idx = [
+                    sets.bus_id2idx[string(bus)] for bus in csv_flexible_bus_id
+                ]
 
-                # all flexible buse
                 if !isnothing(doe_flexible_bus_idx)
                     flex_bus_idx = sort([
                         i for i in union(doe_flexible_bus_idx, csv_flexible_bus_idx)

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,27 +1,28 @@
+IntOrString = Union{Int,AbstractString}
 Base.@kwdef struct Case
     # We create a struct to hold case data in a type-declared format
     # `Base.@kwdef` allows us to instantiate this via keywords
 
-    branchid::Array{Int64,1}
-    branch_from::Array{String,1}
-    branch_to::Array{String,1}
+    branchid::Array{IntOrString,1}
+    branch_from::Array{IntOrString,1}
+    branch_to::Array{IntOrString,1}
     branch_reactance::Array{Float64,1}
     branch_rating::Array{Float64,1}
 
-    dclineid::Array{String,1}
-    dcline_from::Array{String,1}
-    dcline_to::Array{String,1}
+    dclineid::Array{IntOrString,1}
+    dcline_from::Array{IntOrString,1}
+    dcline_to::Array{IntOrString,1}
     dcline_pmin::Array{Float64,1}
     dcline_pmax::Array{Float64,1}
 
-    busid::Array{String,1}
+    busid::Array{IntOrString,1}
     bus_demand::Array{Float64,1}
     bus_zone::Array{Int64,1}
     bus_eiaid::Array{Int64,1}
 
-    genid::Array{String,1}
+    genid::Array{IntOrString,1}
     genfuel::Array{String,1}
-    gen_bus::Array{String,1}
+    gen_bus::Array{IntOrString,1}
     gen_status::BitArray{1}
     gen_pmax::Array{Float64,1}
     gen_pmin::Array{Float64,1}
@@ -90,7 +91,7 @@ Base.@kwdef struct Sets
     num_load_bus::Int64
     bus_idx::UnitRange{Int64}
     load_bus_idx::Array{Int64,1}
-    bus_id2idx::Dict{String,Int64}
+    bus_id2idx::Dict{IntOrString,Int64}
     load_bus_map::SparseMatrixCSC{Int64,Int64}
     # Gen & gen sub-sets
     num_gen::Int64

--- a/src/types.jl
+++ b/src/types.jl
@@ -3,25 +3,25 @@ Base.@kwdef struct Case
     # `Base.@kwdef` allows us to instantiate this via keywords
 
     branchid::Array{Int64,1}
-    branch_from::Array{Int64,1}
-    branch_to::Array{Int64,1}
+    branch_from::Array{String,1}
+    branch_to::Array{String,1}
     branch_reactance::Array{Float64,1}
     branch_rating::Array{Float64,1}
 
-    dclineid::Array{Int64,1}
-    dcline_from::Array{Int64,1}
-    dcline_to::Array{Int64,1}
+    dclineid::Array{String,1}
+    dcline_from::Array{String,1}
+    dcline_to::Array{String,1}
     dcline_pmin::Array{Float64,1}
     dcline_pmax::Array{Float64,1}
 
-    busid::Array{Int64,1}
+    busid::Array{String,1}
     bus_demand::Array{Float64,1}
     bus_zone::Array{Int64,1}
     bus_eiaid::Array{Int64,1}
 
-    genid::Array{Int64,1}
+    genid::Array{String,1}
     genfuel::Array{String,1}
-    gen_bus::Array{Int64,1}
+    gen_bus::Array{String,1}
     gen_status::BitArray{1}
     gen_pmax::Array{Float64,1}
     gen_pmin::Array{Float64,1}
@@ -90,7 +90,7 @@ Base.@kwdef struct Sets
     num_load_bus::Int64
     bus_idx::UnitRange{Int64}
     load_bus_idx::Array{Int64,1}
-    bus_id2idx::Dict{Int64,Int64}
+    bus_id2idx::Dict{String,Int64}
     load_bus_map::SparseMatrixCSC{Int64,Int64}
     # Gen & gen sub-sets
     num_gen::Int64

--- a/src/types.jl
+++ b/src/types.jl
@@ -91,7 +91,7 @@ Base.@kwdef struct Sets
     num_load_bus::Int64
     bus_idx::UnitRange{Int64}
     load_bus_idx::Array{Int64,1}
-    bus_id2idx::Dict{IntOrString,Int64}
+    bus_id2idx::Dict{String,Int64}
     load_bus_map::SparseMatrixCSC{Int64,Int64}
     # Gen & gen sub-sets
     num_gen::Int64


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
Make it so we can handle string or int for certain columns in the grid. This enables using both europe_tub and usa_tamu grid models. 

### What the code is doing
Use a union type when reading in grid csv files, and change the index of `bus_id2idx` to always be string. I'm sure there is a more elegant way to do this, but wanted to get something merged that works.

### Testing
Ran a simulation using usa_tamu, and the 128 node europe grid.


### Time estimate
5 min
